### PR TITLE
Request Norg2 via Isproxy

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -70,12 +70,14 @@ spec:
         extra:
           - "NAVident"
   env:
+    - name: ISPROXY_CLIENT_ID
+      value: "dev-fss.teamsykefravr.isproxy"
+    - name: ISPROXY_URL
+      value: "https://isproxy.dev.intern.nav.no"
     - name: PDL_CLIENT_ID
       value: "dev-fss.pdl.pdl-api"
     - name: PDL_URL
       value: "https://pdl-api.dev.intern.nav.no/graphql"
-    - name: NORG2_URL
-      value: https://app-q1.adeo.no/norg2/api/v1
     - name: SYFOTILGANGSKONTROLL_CLIENT_ID
       value: "dev-fss.teamsykefravr.syfo-tilgangskontroll"
     - name: TILGANGSKONTROLLAPI_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -70,12 +70,14 @@ spec:
         extra:
           - "NAVident"
   env:
+    - name: ISPROXY_CLIENT_ID
+      value: "prod-fss.teamsykefravr.isproxy"
+    - name: ISPROXY_URL
+      value: "https://isproxy.intern.nav.no"
     - name: PDL_CLIENT_ID
       value: "prod-fss.pdl.pdl-api"
     - name: PDL_URL
       value: "https://pdl-api.intern.nav.no/graphql"
-    - name: NORG2_URL
-      value: https://app.adeo.no/norg2/api/v1
     - name: SYFOTILGANGSKONTROLL_CLIENT_ID
       value: "prod-fss.teamsykefravr.syfo-tilgangskontroll"
     - name: TILGANGSKONTROLLAPI_URL

--- a/src/test/kotlin/no/nav/syfo/testhelper/Norg2Mock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/Norg2Mock.kt
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.syfo.consumer.norg.NorgConsumer
 import no.nav.syfo.consumer.norg.Enhetsstatus
 import no.nav.syfo.consumer.norg.NorgEnhet
-import org.springframework.http.HttpMethod
-import org.springframework.http.MediaType
+import org.springframework.http.*
 import org.springframework.test.web.client.ExpectedCount
 import org.springframework.test.web.client.MockRestServiceServer
 import org.springframework.test.web.client.match.MockRestRequestMatchers
@@ -25,11 +24,14 @@ fun mockAndExpectNorgArbeidsfordeling(
         .path(NorgConsumer.ARBEIDSFORDELING_BESTMATCH_PATH)
         .toUriString()
 
+    val systemToken = generateAzureAdV2TokenResponse().access_token
+
     try {
         val json = ObjectMapper().writeValueAsString(enhetList)
 
-        mockRestServiceServer.expect(ExpectedCount.manyTimes(), MockRestRequestMatchers.requestTo(uriString))
+        mockRestServiceServer.expect(ExpectedCount.once(), MockRestRequestMatchers.requestTo(uriString))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
+            .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer $systemToken"))
             .andRespond(MockRestResponseCreators.withSuccess(json, MediaType.APPLICATION_JSON))
     } catch (e: JsonProcessingException) {
         e.printStackTrace()

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -34,6 +34,7 @@ azure:
 pdl.client.id: "dev-fss.pdl.pdl-apiq"
 syfotilgangskontroll.client.id: "syfotilgangskontrollId"
 
-norg2.url: https://norg2
+isproxy.client.id: "dev-fss:teamsykefravr:isproxy"
+isproxy.url: "https://isproxy"
 pdl.url: "http://pdl"
 tilgangskontrollapi.url: "http://syfotilgangskontroll"


### PR DESCRIPTION
Replace request to Norg2 to with a request to Norg2 via Isproxy with AzureAD authentication, to enabled migration to GCP