### PR TITLE
Change name of db-table

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/database/domain/PPerson.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/database/domain/PPerson.kt
@@ -1,11 +1,11 @@
 package no.nav.syfo.behandlendeenhet.database.domain
 
-import no.nav.syfo.behandlendeenhet.domain.NavUtland
+import no.nav.syfo.behandlendeenhet.domain.Person
 import no.nav.syfo.domain.PersonIdentNumber
 import java.time.OffsetDateTime
 import java.util.*
 
-data class PNavUtland(
+data class PPerson(
     val id: Int,
     val uuid: UUID,
     val personident: String,
@@ -14,7 +14,7 @@ data class PNavUtland(
     val updatedAt: OffsetDateTime,
 )
 
-fun PNavUtland.toNavUtland() = NavUtland(
+fun PPerson.toPerson() = Person(
     uuid = this.uuid,
     personident = PersonIdentNumber(this.personident),
     isNavUtland = this.isNavUtland

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Person.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Person.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.behandlendeenhet.domain
 import no.nav.syfo.domain.PersonIdentNumber
 import java.util.*
 
-data class NavUtland(
+data class Person(
     val uuid: UUID,
     val personident: PersonIdentNumber,
     val isNavUtland: Boolean

--- a/src/main/resources/db/migration/V1_4__create_table_person_and_drop_nav_utland.sql
+++ b/src/main/resources/db/migration/V1_4__create_table_person_and_drop_nav_utland.sql
@@ -1,0 +1,14 @@
+CREATE TABLE PERSON
+(
+    id            SERIAL PRIMARY KEY,
+    uuid          VARCHAR(50) NOT NULL UNIQUE,
+    personident   VARCHAR(11) NOT NULL UNIQUE,
+    is_nav_utland BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at    timestamptz NOT NULL,
+    updated_at    timestamptz NOT NULL
+);
+
+GRANT SELECT ON PERSON TO cloudsqliamuser;
+GRANT SELECT ON PERSON TO "isyfo-analyse";
+
+DROP TABLE NAV_UTLAND;


### PR DESCRIPTION
Nav_Utland som navn virker litt rart, ettersom at innholdet i tabellen egentlig er en oversikt over personer og feltet is_nav_utland. Ved å kalle den `person` er vi mer rustet for en fremtidig utvidelse av tabellen også.