### PR TITLE
Add identhendelse service

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -103,4 +103,4 @@ spec:
     - name: SYFOTILGANGSKONTROLL_URL
       value: "https://syfo-tilgangskontroll.dev-fss-pub.nais.io"
     - name: TOGGLE_KAFKA_IDENTHENDELSE_CONSUMER_ENABLED
-      value: "false"
+      value: "true"

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -17,6 +17,7 @@ import no.nav.syfo.behandlendeenhet.kafka.kafkaBehandlendeEnhetProducerConfig
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.client.wellknown.getWellKnown
+import no.nav.syfo.identhendelse.IdenthendelseService
 import no.nav.syfo.identhendelse.kafka.IdenthendelseConsumerService
 import no.nav.syfo.identhendelse.kafka.launchKafkaTaskIdenthendelse
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -93,7 +94,13 @@ fun main() {
         application.environment.log.info("Application is ready, running Java VM ${Runtime.version()}")
 
         if (environment.toggleKafkaConsumerIdenthendelseEnabled) {
-            val kafkaIdenthendelseConsumerService = IdenthendelseConsumerService()
+            val identhendelseService = IdenthendelseService(
+                database = applicationDatabase,
+                pdlClient = pdlClient,
+            )
+            val kafkaIdenthendelseConsumerService = IdenthendelseConsumerService(
+                identhendelseService = identhendelseService,
+            )
             launchKafkaTaskIdenthendelse(
                 applicationState = applicationState,
                 applicationEnvironmentKafka = environment.kafka,

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -20,14 +20,16 @@ import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.client.skjermedepersonerpip.SkjermedePersonerPipClient
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.client.wellknown.WellKnown
-import redis.clients.jedis.*
 
 fun Application.apiModule(
     applicationState: ApplicationState,
+    azureAdClient: AzureAdClient,
     environment: Environment,
     wellKnownInternalAzureAD: WellKnown,
     database: DatabaseInterface,
     behandlendeEnhetProducer: BehandlendeEnhetProducer,
+    pdlClient: PdlClient,
+    redisStore: RedisStore,
 ) {
     installMetrics()
     installCallId()
@@ -43,31 +45,10 @@ fun Application.apiModule(
     )
     installStatusPages()
 
-    val redisStore = RedisStore(
-        jedisPool = JedisPool(
-            JedisPoolConfig(),
-            environment.redisHost,
-            environment.redisPort,
-            Protocol.DEFAULT_TIMEOUT,
-            environment.redisSecret,
-        ),
-    )
-
-    val azureAdClient = AzureAdClient(
-        azureAppClientId = environment.azureAppClientId,
-        azureAppClientSecret = environment.azureAppClientSecret,
-        azureOpenidConfigTokenEndpoint = environment.azureOpenidConfigTokenEndpoint,
-        redisStore = redisStore,
-    )
-
     val norgClient = NorgClient(
         baseUrl = environment.norg2Url,
     )
-    val pdlClient = PdlClient(
-        azureAdClient = azureAdClient,
-        baseUrl = environment.pdlUrl,
-        clientId = environment.pdlClientId,
-    )
+
     val skjermedePersonerPipClient = SkjermedePersonerPipClient(
         azureAdClient = azureAdClient,
         baseUrl = environment.skjermedePersonerPipUrl,

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -4,7 +4,7 @@ import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.behandlendeenhet.database.domain.toPerson
 import no.nav.syfo.behandlendeenhet.database.getPersonByIdent
-import no.nav.syfo.behandlendeenhet.database.updatePerson
+import no.nav.syfo.behandlendeenhet.database.createOrUpdatePerson
 import no.nav.syfo.behandlendeenhet.domain.Person
 import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetProducer
 import no.nav.syfo.client.norg.NorgClient
@@ -73,7 +73,7 @@ class EnhetService(
     }
 
     fun updatePerson(personIdent: PersonIdentNumber, isNavUtland: Boolean): Person? {
-        val pPerson = database.updatePerson(personIdent, isNavUtland)
+        val pPerson = database.createOrUpdatePerson(personIdent, isNavUtland)
         val person = pPerson?.toPerson()
         if (person != null) {
             val cacheKey = "$CACHE_BEHANDLENDEENHET_PERSONIDENT_KEY_PREFIX${personIdent.value}"

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/database/PersonQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/database/PersonQuery.kt
@@ -30,7 +30,7 @@ const val queryUpdatePerson =
             updated_at;
     """
 
-fun DatabaseInterface.updatePerson(
+fun DatabaseInterface.createOrUpdatePerson(
     personIdent: PersonIdentNumber,
     isNavUtland: Boolean
 ): PPerson? {

--- a/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlIdenterResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlIdenterResponse.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.client.pdl.domain
 
+import no.nav.syfo.domain.PersonIdentNumber
+
 data class PdlIdenterResponse(
     val data: PdlHentIdenter?,
     val errors: List<PdlError>?
@@ -15,6 +17,9 @@ data class PdlIdenter(
     val aktivIdent: String? = identer.firstOrNull {
         it.gruppe == IdentType.FOLKEREGISTERIDENT && !it.historisk
     }?.ident
+    fun aktivIdentIsHistorisk(newIdent: PersonIdentNumber): Boolean {
+        return identer.any { it.ident == newIdent.value && it.historisk }
+    }
 }
 
 data class PdlIdent(

--- a/src/main/kotlin/no/nav/syfo/identhendelse/IdenthendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/IdenthendelseService.kt
@@ -1,0 +1,69 @@
+package no.nav.syfo.identhendelse
+
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.behandlendeenhet.database.getPersonByIdent
+import no.nav.syfo.client.pdl.PdlClient
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.identhendelse.database.deletePerson
+import no.nav.syfo.identhendelse.database.updatePerson
+import no.nav.syfo.identhendelse.kafka.COUNT_KAFKA_CONSUMER_PDL_AKTOR_UPDATES
+import no.nav.syfo.identhendelse.kafka.KafkaIdenthendelseDTO
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class IdenthendelseService(
+    private val database: DatabaseInterface,
+    private val pdlClient: PdlClient,
+) {
+
+    private val log: Logger = LoggerFactory.getLogger(IdenthendelseService::class.java)
+
+    fun handleIdenthendelse(identhendelse: KafkaIdenthendelseDTO) {
+        if (identhendelse.folkeregisterIdenter.size > 1) {
+            val activeIdent = identhendelse.getActivePersonident()
+            if (activeIdent != null) {
+                val inactiveIdenter = identhendelse.getInactivePersonidenter()
+                val oldPersonIdentList = inactiveIdenter.mapNotNull { personident ->
+                    val person = database.getPersonByIdent(personident)
+                    if (person != null) PersonIdentNumber(person.personident) else null
+                }
+
+                if (oldPersonIdentList.isNotEmpty()) {
+                    checkThatPdlIsUpdated(activeIdent)
+                    val numberOfUpdatedIdenter = updatePersonOrDeleteOldVersions(activeIdent, oldPersonIdentList)
+                    log.info("Identhendelse: Updated $numberOfUpdatedIdenter rows based on Identhendelse from PDL")
+                    COUNT_KAFKA_CONSUMER_PDL_AKTOR_UPDATES.increment(numberOfUpdatedIdenter.toDouble())
+                }
+            } else {
+                log.warn("Mangler gyldig ident fra PDL")
+            }
+        }
+    }
+
+    private fun updatePersonOrDeleteOldVersions(
+        activeIdent: PersonIdentNumber,
+        oldPersonIdentList: List<PersonIdentNumber>
+    ): Int {
+        var updatedRows = 0
+        val personActiveIdent = database.getPersonByIdent(activeIdent)
+        if (personActiveIdent != null) {
+            var deletedRows = 0
+            oldPersonIdentList.forEach { deletedRows += database.deletePerson(it) }
+            log.info("Identhendelse: Deleted $deletedRows entries with an inactive personident from database.")
+        } else {
+            updatedRows += database.updatePerson(activeIdent, oldPersonIdentList.first())
+        }
+        return updatedRows
+    }
+
+    // Erfaringer fra andre team tilsier at vi burde dobbeltsjekke at ting har blitt oppdatert i PDL før vi gjør endringer
+    private fun checkThatPdlIsUpdated(nyIdent: PersonIdentNumber) {
+        runBlocking {
+            val pdlIdenter = pdlClient.getPdlIdenter(nyIdent)?.hentIdenter
+            if (nyIdent.value != pdlIdenter?.aktivIdent && pdlIdenter?.aktivIdentIsHistorisk(nyIdent) != true) {
+                throw IllegalStateException("Ny ident er ikke aktiv ident i PDL")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/identhendelse/database/IdenthendelseQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/database/IdenthendelseQuery.kt
@@ -1,0 +1,47 @@
+package no.nav.syfo.identhendelse.database
+
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.util.nowUTC
+
+const val queryUpdatePerson =
+    """
+        UPDATE PERSON
+        SET personident = ?, updated_at = ?
+        WHERE personident = ?
+    """
+
+fun DatabaseInterface.updatePerson(nyPersonident: PersonIdentNumber, oldIdent: PersonIdentNumber): Int {
+    var updatedRows: Int
+    val now = nowUTC()
+    this.connection.use { connection ->
+        updatedRows = connection.prepareStatement(queryUpdatePerson).use {
+            it.setString(1, nyPersonident.value)
+            it.setObject(2, now)
+            it.setString(3, oldIdent.value)
+            it.executeUpdate()
+        }.also {
+            connection.commit()
+        }
+    }
+    return updatedRows
+}
+
+const val queryDeletePerson =
+    """
+        DELETE FROM PERSON
+        WHERE personident = ?
+    """
+
+fun DatabaseInterface.deletePerson(personIdent: PersonIdentNumber): Int {
+    var deletedRows: Int
+    this.connection.use { connection ->
+        deletedRows = connection.prepareStatement(queryDeletePerson).use {
+            it.setString(1, personIdent.value)
+            it.executeUpdate()
+        }.also {
+            connection.commit()
+        }
+    }
+    return deletedRows
+}

--- a/src/main/kotlin/no/nav/syfo/identhendelse/kafka/KafkaIdenthendelseConsumerConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/kafka/KafkaIdenthendelseConsumerConfig.kt
@@ -12,7 +12,7 @@ fun kafkaIdenthendelseConsumerConfig(
 ): Properties {
     return Properties().apply {
         putAll(commonKafkaConsumerConfig(applicationEnvironmentKafka))
-        this[ConsumerConfig.GROUP_ID_CONFIG] = "syfobehandlendeenhet-v0"
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "syfobehandlendeenhet-v1"
         this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = KafkaAvroDeserializer::class.java.canonicalName
         this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1"
 

--- a/src/main/kotlin/no/nav/syfo/identhendelse/kafka/KafkaIdenthendelseTask.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/kafka/KafkaIdenthendelseTask.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.identhendelse.kafka
 
-import kotlinx.coroutines.runBlocking
 import no.nav.syfo.application.ApplicationEnvironmentKafka
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.launchBackgroundTask
@@ -25,15 +24,15 @@ fun launchKafkaTaskIdenthendelse(
         val kafkaConfig = kafkaIdenthendelseConsumerConfig(applicationEnvironmentKafka)
         val kafkaConsumer = KafkaConsumer<String, GenericRecord>(kafkaConfig)
 
-        kafkaConsumer.subscribe(
-            listOf(PDL_AKTOR_TOPIC)
-        )
+        kafkaConsumer.subscribe(listOf(PDL_AKTOR_TOPIC))
+
         while (applicationState.ready) {
-            runBlocking {
-                kafkaIdenthendelseConsumerService.pollAndProcessRecords(
-                    kafkaConsumer = kafkaConsumer,
-                )
+            if (kafkaConsumer.subscription().isEmpty()) {
+                kafkaConsumer.subscribe(listOf(PDL_AKTOR_TOPIC))
             }
+            kafkaIdenthendelseConsumerService.pollAndProcessRecords(
+                kafkaConsumer = kafkaConsumer,
+            )
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.util
+
+import java.time.*
+
+val defaultZoneOffset: ZoneOffset = ZoneOffset.UTC
+
+fun nowUTC(): OffsetDateTime = OffsetDateTime.now(defaultZoneOffset)

--- a/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
@@ -1,0 +1,133 @@
+package no.nav.syfo.identhendelse
+
+import io.ktor.server.testing.*
+import kotlinx.coroutines.*
+import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.behandlendeenhet.database.getPersonByIdent
+import no.nav.syfo.behandlendeenhet.database.createOrUpdatePerson
+import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.pdl.PdlClient
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.dropData
+import no.nav.syfo.testhelper.generator.generateKafkaIdenthendelseDTO
+import org.amshove.kluent.internal.assertFailsWith
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolConfig
+import redis.clients.jedis.Protocol
+
+object IdenthendelseServiceSpek : Spek({
+
+    describe(IdenthendelseServiceSpek::class.java.simpleName) {
+
+        with(TestApplicationEngine()) {
+            start()
+
+            val externalMockEnvironment = ExternalMockEnvironment.instance
+            val database = externalMockEnvironment.database
+            val azureAdClient = AzureAdClient(
+                azureAppClientId = externalMockEnvironment.environment.azureAppClientId,
+                azureAppClientSecret = externalMockEnvironment.environment.azureAppClientSecret,
+                azureOpenidConfigTokenEndpoint = externalMockEnvironment.environment.azureOpenidConfigTokenEndpoint,
+                redisStore = RedisStore(
+                    JedisPool(
+                        JedisPoolConfig(),
+                        externalMockEnvironment.environment.redisHost,
+                        externalMockEnvironment.environment.redisPort,
+                        Protocol.DEFAULT_TIMEOUT,
+                        externalMockEnvironment.environment.redisSecret,
+                    )
+                ),
+            )
+            val pdlClient = PdlClient(
+                azureAdClient = azureAdClient,
+                baseUrl = externalMockEnvironment.environment.pdlUrl,
+                clientId = externalMockEnvironment.environment.pdlClientId,
+            )
+
+            val identhendelseService = IdenthendelseService(
+                database = database,
+                pdlClient = pdlClient,
+            )
+
+            afterEachTest {
+                database.dropData()
+            }
+
+            describe("Happy path") {
+                it("Skal oppdatere person når person har fått ny ident") {
+                    val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTO(hasOldPersonident = true)
+                    val newIdent = kafkaIdenthendelseDTO.getActivePersonident()!!
+                    val oldIdent = kafkaIdenthendelseDTO.getInactivePersonidenter().first()
+
+                    val oldUpdatedAt = database.createOrUpdatePerson(
+                        personIdent = oldIdent,
+                        isNavUtland = false,
+                    )?.updatedAt
+
+                    runBlocking {
+                        identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
+                    }
+
+                    val updatedPerson = database.getPersonByIdent(newIdent)
+                    updatedPerson?.personident shouldBeEqualTo newIdent.value
+                    updatedPerson?.updatedAt shouldNotBeEqualTo oldUpdatedAt
+
+                    val oldPerson = database.getPersonByIdent(oldIdent)
+                    oldPerson shouldBeEqualTo null
+                }
+
+                it("Skal slette gammel person når ny ident allerede finnes i databasen") {
+                    val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTO(hasOldPersonident = true)
+                    val newIdent = kafkaIdenthendelseDTO.getActivePersonident()!!
+                    val oldIdent = kafkaIdenthendelseDTO.getInactivePersonidenter().first()
+
+                    database.createOrUpdatePerson(
+                        personIdent = newIdent,
+                        isNavUtland = true,
+                    )
+
+                    database.createOrUpdatePerson(
+                        personIdent = oldIdent,
+                        isNavUtland = false,
+                    )
+
+                    runBlocking {
+                        identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
+                    }
+
+                    val updatedPerson = database.getPersonByIdent(newIdent)
+                    updatedPerson?.personident shouldBeEqualTo newIdent.value
+
+                    val oldPerson = database.getPersonByIdent(oldIdent)
+                    oldPerson shouldBeEqualTo null
+                }
+            }
+
+            describe("Unhappy path") {
+                it("Skal kaste feil hvis PDL ikke har oppdatert identen") {
+                    val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTO(
+                        personident = UserConstants.ARBEIDSTAKER_PERSONIDENT_3,
+                        hasOldPersonident = true,
+                    )
+                    val oldIdent = kafkaIdenthendelseDTO.getInactivePersonidenter().first()
+
+                    database.createOrUpdatePerson(
+                        personIdent = oldIdent,
+                        isNavUtland = false,
+                    )
+
+                    runBlocking {
+                        assertFailsWith(IllegalStateException::class) {
+                            identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -2,17 +2,47 @@ package no.nav.syfo.testhelper
 
 import io.ktor.server.application.*
 import no.nav.syfo.application.api.apiModule
+import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetProducer
+import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.pdl.PdlClient
+import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolConfig
+import redis.clients.jedis.Protocol
 
 fun Application.testApiModule(
     externalMockEnvironment: ExternalMockEnvironment,
     behandlendeEnhetProducer: BehandlendeEnhetProducer,
 ) {
+    val redisStore = RedisStore(
+        JedisPool(
+            JedisPoolConfig(),
+            externalMockEnvironment.environment.redisHost,
+            externalMockEnvironment.environment.redisPort,
+            Protocol.DEFAULT_TIMEOUT,
+            externalMockEnvironment.environment.redisSecret,
+        )
+    )
+    val azureAdClient = AzureAdClient(
+        azureAppClientId = externalMockEnvironment.environment.azureAppClientId,
+        azureAppClientSecret = externalMockEnvironment.environment.azureAppClientSecret,
+        azureOpenidConfigTokenEndpoint = externalMockEnvironment.environment.azureOpenidConfigTokenEndpoint,
+        redisStore = redisStore,
+    )
+    val pdlClient = PdlClient(
+        azureAdClient = azureAdClient,
+        baseUrl = externalMockEnvironment.environment.pdlUrl,
+        clientId = externalMockEnvironment.environment.pdlClientId,
+    )
     this.apiModule(
         applicationState = externalMockEnvironment.applicationState,
+        azureAdClient = azureAdClient,
         environment = externalMockEnvironment.environment,
         wellKnownInternalAzureAD = externalMockEnvironment.wellKnownInternalAzureAD,
         database = externalMockEnvironment.database,
         behandlendeEnhetProducer = behandlendeEnhetProducer,
+        pdlClient = pdlClient,
+        redisStore = redisStore,
+
     )
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaIdenthendelseDTOGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaIdenthendelseDTOGenerator.kt
@@ -1,0 +1,42 @@
+package no.nav.syfo.testhelper.generator
+
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.identhendelse.kafka.IdentType
+import no.nav.syfo.identhendelse.kafka.Identifikator
+import no.nav.syfo.identhendelse.kafka.KafkaIdenthendelseDTO
+import no.nav.syfo.testhelper.UserConstants
+
+fun generateKafkaIdenthendelseDTO(
+    personident: PersonIdentNumber = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+    hasOldPersonident: Boolean,
+): KafkaIdenthendelseDTO {
+    val identifikatorer = mutableListOf(
+        Identifikator(
+            idnummer = personident.value,
+            type = IdentType.FOLKEREGISTERIDENT,
+            gjeldende = true,
+        ),
+        Identifikator(
+            idnummer = "10${personident.value}",
+            type = IdentType.AKTORID,
+            gjeldende = true
+        ),
+    )
+    if (hasOldPersonident) {
+        identifikatorer.addAll(
+            listOf(
+                Identifikator(
+                    idnummer = UserConstants.ARBEIDSTAKER_PERSONIDENT_2.value,
+                    type = IdentType.FOLKEREGISTERIDENT,
+                    gjeldende = false,
+                ),
+                Identifikator(
+                    idnummer = "9${UserConstants.ARBEIDSTAKER_PERSONIDENT_2.value.drop(1)}",
+                    type = IdentType.FOLKEREGISTERIDENT,
+                    gjeldende = false,
+                ),
+            )
+        )
+    }
+    return KafkaIdenthendelseDTO(identifikatorer)
+}


### PR DESCRIPTION
Oppdaget to forbedringer under arbeidet med denne PRen:
1. Retry-mekanismen ved feil i håndteringen av identhendelser fungerte ikke helt som vi trodde. Nå er det fikset ved å unsubscribe topicen i `catch`-blokka, i tillegg til å vente 1 minutt. Når den da subscriber på nytt, vil den plukke opp offset på riktig plass og fortsette. Dette krever at vi endrer logikk i flere av appene 😤 Men godt vi oppdaget det før alt er på i prod.
2. `updated_at` feltet burde oppdateres sammen med identendring 