### PR TITLE
Increase cache time to twelve hours

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -104,6 +104,6 @@ class EnhetService(
 
     companion object {
         const val CACHE_BEHANDLENDEENHET_PERSONIDENT_KEY_PREFIX = "behandlendeenhet-personident-"
-        const val CACHE_BEHANDLENDEENHET_PERSONIDENT_EXPIRE_SECONDS = 2 * 60 * 60L
+        const val CACHE_BEHANDLENDEENHET_PERSONIDENT_EXPIRE_SECONDS = 12 * 60 * 60L
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/skjermedepersonerpip/SkjermedePersonerPipClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/skjermedepersonerpip/SkjermedePersonerPipClient.kt
@@ -68,7 +68,7 @@ class SkjermedePersonerPipClient(
 
     companion object {
         const val CACHE_SKJERMET_PERSONIDENT_KEY_PREFIX = "skjermet-personident"
-        const val CACHE_SKJERMET_PERSONIDENT_EXPIRE_SECONDS = 60 * 60L
+        const val CACHE_SKJERMET_PERSONIDENT_EXPIRE_SECONDS = 12 * 60 * 60L
 
         private val log = LoggerFactory.getLogger(SkjermedePersonerPipClient::class.java)
     }


### PR DESCRIPTION
We cache for 12 hours in tilgangskontroll, so it should be fine here as well.
PDL should also get cache, but the currently used apis will be replaced by pip api, we'll add cache then.