### PR TITLE
IS-3147: Hente mulige oppfolgingsenheter

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -73,6 +73,7 @@ fun main() {
 
     val norgClient = NorgClient(
         baseUrl = environment.norg2Url,
+        valkeyStore = valkeyStore,
     )
 
     val skjermedePersonerPipClient = SkjermedePersonerPipClient(

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -120,9 +120,9 @@ class EnhetService(
 
     suspend fun getMuligeOppfolgingsenheter(
         callId: String,
-        underordnetEnhet: Enhet,
+        enhet: Enhet,
     ): List<BehandlendeEnhet> {
-        val overordnet = norgClient.getOverordnetEnhet(callId, underordnetEnhet)
+        val overordnet = norgClient.getOverordnetEnhet(callId, enhet)
         return if (overordnet != null) {
             norgClient.getUnderenheter(callId, Enhet(overordnet.enhetNr)).map {
                 BehandlendeEnhet(

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -74,7 +74,7 @@ class EnhetService(
     ): BehandlendeEnhet? {
         val cacheKey = "$CACHE_GEOGRAFISKENHET_PERSONIDENT_KEY_PREFIX${personIdentNumber.value}"
         val cachedBehandlendeEnhet: BehandlendeEnhet? = valkeyStore.getObject(key = cacheKey)
-        return if (cachedBehandlendeEnhet != null && cachedBehandlendeEnhet.navn != ENHETSNAVN_MANGLER) {
+        return if (cachedBehandlendeEnhet != null) {
             cachedBehandlendeEnhet
         } else {
             val geografiskTilknytning = pdlClient.geografiskTilknytning(

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -118,6 +118,23 @@ class EnhetService(
         }
     }
 
+    suspend fun getMuligeOppfolgingsenheter(
+        callId: String,
+        underordnetEnhet: Enhet,
+    ): List<BehandlendeEnhet> {
+        val overordnet = norgClient.getOverordnetEnhet(callId, underordnetEnhet)
+        return if (overordnet != null) {
+            norgClient.getUnderenheter(callId, Enhet(overordnet.enhetNr)).map {
+                BehandlendeEnhet(
+                    enhetId = it.enhetNr,
+                    navn = it.navn,
+                )
+            }
+        } else {
+            emptyList()
+        }
+    }
+
     private suspend fun validateForOppfolgingsenhet(
         callId: String,
         personIdent: PersonIdentNumber,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cache/ValkeyStore.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cache/ValkeyStore.kt
@@ -32,6 +32,15 @@ class ValkeyStore(
         }
     }
 
+    inline fun <reified T> getListObject(key: String): List<T>? {
+        val value = get(key)
+        return if (value != null) {
+            objectMapper.readValue(value, objectMapper.typeFactory.constructCollectionType(ArrayList::class.java, T::class.java))
+        } else {
+            null
+        }
+    }
+
     fun <T> setObject(
         key: String,
         value: T,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
@@ -140,7 +140,7 @@ class NorgClient(
             cachedEnhet
         } else {
             COUNT_CALL_NORG_OVERORDNET_ENHET_CACHE_MISS.increment()
-            val url = getOverordnetEnheterForNAVKontorUrl(enhet.value)
+            val url = getOverordnetEnhetForNAVKontorUrl(enhet.value)
             val enhet: NorgEnhet? = try {
                 val response: List<NorgEnhet> = httpClient.get(url) {
                     header(NAV_CALL_ID_HEADER, callId)
@@ -148,7 +148,7 @@ class NorgClient(
                 }.body()
 
                 if (response.isEmpty()) {
-                    log.warn("No overordnede enheter returned from NORG2 for enhet $enhet, callId=$callId")
+                    log.warn("No overordnet enhet returned from NORG2 for enhet $enhet, callId=$callId")
                 }
                 response.firstOrNull()
             } catch (e: ResponseException) {
@@ -222,7 +222,7 @@ class NorgClient(
     private fun getBehandlingstype() =
         ArbeidsfordelingCriteriaBehandlingstype.SYKEFRAVAERSOPPFOLGING.behandlingstype
 
-    private fun getOverordnetEnheterForNAVKontorUrl(enhetNr: String): String {
+    private fun getOverordnetEnhetForNAVKontorUrl(enhetNr: String): String {
         return "$baseUrl/norg2/api/v1/enhet/$enhetNr/overordnet?organiseringsType=$ORGANISERINGSTYPE"
     }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
@@ -123,7 +123,7 @@ class NorgClient(
         } else {
             COUNT_CALL_NORG_OVERORDNET_ENHET_CACHE_MISS.increment()
             val url = getOverordnetEnhetForNAVKontorUrl(enhet.value)
-            val enhet: NorgEnhet? = try {
+            val norgEnhet: NorgEnhet? = try {
                 val response: List<NorgEnhet> = httpClient.get(url) {
                     header(NAV_CALL_ID_HEADER, callId)
                     accept(ContentType.Application.Json)
@@ -143,14 +143,14 @@ class NorgClient(
                     throw e
                 }
             }
-            if (enhet != null) {
+            if (norgEnhet != null) {
                 valkeyStore.setObject(
                     key = cacheKey,
-                    value = enhet,
+                    value = norgEnhet,
                     expireSeconds = CACHE_NORG_EXPIRE_SECONDS
                 )
             }
-            enhet
+            norgEnhet
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
@@ -62,37 +62,22 @@ class NorgClient(
         geografiskTilknytning: GeografiskTilknytning,
         isEgenAnsatt: Boolean,
     ): BehandlendeEnhet? {
-        val cacheKey = "${CACHE_NORGENHET_GEOGRAFISK_KEY_PREFIX}$geografiskTilknytning"
-        val cachedEnhet: BehandlendeEnhet? = valkeyStore.getObject(key = cacheKey)
-        return if (cachedEnhet != null) {
-            COUNT_CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_HIT.increment()
-            cachedEnhet
-        } else {
-            COUNT_CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_MISS.increment()
-            val enheter = getArbeidsfordelingEnheter(
-                callId = callId,
-                diskresjonskode = diskresjonskode,
-                geografiskTilknytning = geografiskTilknytning,
-                isEgenAnsatt = isEgenAnsatt,
-            )
-            val enhet = enheter
-                .filter { it.status == Enhetsstatus.AKTIV.formattedName }
-                .map {
-                    BehandlendeEnhet(
-                        it.enhetNr,
-                        it.navn
-                    )
-                }
-                .firstOrNull()
-            if (enhet != null) {
-                valkeyStore.setObject(
-                    key = cacheKey,
-                    value = enhet,
-                    expireSeconds = CACHE_NORG_EXPIRE_SECONDS
+        val enheter = getArbeidsfordelingEnheter(
+            callId = callId,
+            diskresjonskode = diskresjonskode,
+            geografiskTilknytning = geografiskTilknytning,
+            isEgenAnsatt = isEgenAnsatt,
+        )
+        val enhet = enheter
+            .filter { it.status == Enhetsstatus.AKTIV.formattedName }
+            .map {
+                BehandlendeEnhet(
+                    it.enhetNr,
+                    it.navn
                 )
             }
-            enhet
-        }
+            .firstOrNull()
+        return enhet
     }
 
     private suspend fun getArbeidsfordelingEnheter(
@@ -234,7 +219,6 @@ class NorgClient(
         private val log = getLogger(NorgClient::class.java)
 
         const val CACHE_NORGENHET_KEY_PREFIX = "norgenhet-enhetnr-"
-        const val CACHE_NORGENHET_GEOGRAFISK_KEY_PREFIX = "norgenhet-geografisktilknytning-"
         const val CACHE_NORGENHET_OVERORDNET_KEY_PREFIX = "norgenhet-overordnet-"
         const val CACHE_NORGENHET_UNDERORDNET_KEY_PREFIX = "norgenhet-underordnet-"
         const val CACHE_NORG_EXPIRE_SECONDS = 12 * 60 * 60L

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
@@ -61,14 +61,13 @@ class NorgClient(
         diskresjonskode: ArbeidsfordelingCriteriaDiskresjonskode?,
         geografiskTilknytning: GeografiskTilknytning,
         isEgenAnsatt: Boolean,
-    ): BehandlendeEnhet? {
-        val enheter = getArbeidsfordelingEnheter(
+    ): BehandlendeEnhet? =
+        getArbeidsfordelingEnheter(
             callId = callId,
             diskresjonskode = diskresjonskode,
             geografiskTilknytning = geografiskTilknytning,
             isEgenAnsatt = isEgenAnsatt,
         )
-        val enhet = enheter
             .filter { it.status == Enhetsstatus.AKTIV.formattedName }
             .map {
                 BehandlendeEnhet(
@@ -77,8 +76,6 @@ class NorgClient(
                 )
             }
             .firstOrNull()
-        return enhet
-    }
 
     private suspend fun getArbeidsfordelingEnheter(
         callId: String,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
@@ -102,7 +102,7 @@ class NorgClient(
         enhet: Enhet,
     ): NorgEnhet? {
         val url = getOverordnetEnheterForNAVKontorUrl(enhet.value)
-        try {
+        return try {
             val response: List<NorgEnhet> = httpClient.get(url) {
                 header(NAV_CALL_ID_HEADER, callId)
                 accept(ContentType.Application.Json)
@@ -111,10 +111,10 @@ class NorgClient(
             if (response.isEmpty()) {
                 log.warn("No overordnede enheter returned from NORG2 for enhet $enhet, callId=$callId")
             }
-            return response.firstOrNull()
+            response.firstOrNull()
         } catch (e: ResponseException) {
             if (e.response.status == HttpStatusCode.NotFound) {
-                return null
+                null
             } else {
                 val message = "Call to NORG2 for overordnet enhet failed with status HTTP-${e.response.status} for enhet $enhet, callId=$callId"
                 log.error(message)
@@ -128,7 +128,7 @@ class NorgClient(
         enhet: Enhet,
     ): List<NorgEnhet> {
         val url = getOrganiseringForEnhetUrl(enhet.value)
-        try {
+        return try {
             val response: List<RsOrganisering> = httpClient.get(url) {
                 header(NAV_CALL_ID_HEADER, callId)
                 accept(ContentType.Application.Json)
@@ -138,13 +138,13 @@ class NorgClient(
                 log.error("No underenheter returned from NORG2 for enhet $enhet, callId=$callId")
                 throw RuntimeException("No underenheter returned from NORG2 for enhet $enhet, callId=$callId")
             }
-            return response
+            response
                 .mapNotNull { it.organisertUnder?.nr }
                 .mapNotNull { getNorgEnhet(it) }
                 .filter { it.type == ENHET_TYPE_LOKAL && it.status == Enhetsstatus.AKTIV.formattedName }
         } catch (e: ResponseException) {
             if (e.response.status == HttpStatusCode.NotFound) {
-                return emptyList()
+                emptyList()
             } else {
                 val message = "Call to NORG2 for overordnet enhet failed with status HTTP-${e.response.status} for enhet $enhet, callId=$callId"
                 log.error(message)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClientMetric.kt
@@ -8,6 +8,14 @@ import no.nav.syfo.infrastructure.metric.METRICS_REGISTRY
 const val CALL_NORG_ARBEIDSFORDELING_BASE = "${METRICS_NS}_call_norg_arbeidsfordeling"
 const val CALL_NORG_ARBEIDSFORDELING_SUCCESS = "${CALL_NORG_ARBEIDSFORDELING_BASE}_success_count"
 const val CALL_NORG_ARBEIDSFORDELING_FAIL = "${CALL_NORG_ARBEIDSFORDELING_BASE}_fail_count"
+const val CALL_NORG_ENHET_CACHE_HIT = "${METRICS_NS}_call_norg_enhet_cache_hit"
+const val CALL_NORG_ENHET_CACHE_MISS = "${METRICS_NS}_call_norg_enhet_cache_miss"
+const val CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_HIT = "${METRICS_NS}_call_norg_arbeidsfordeling_enhet_cache_hit"
+const val CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_MISS = "${METRICS_NS}_call_norg_arbeidsfordeling_enhet_cache_miss"
+const val CALL_NORG_OVERORDNET_ENHET_CACHE_HIT = "${METRICS_NS}_call_norg_overordnet_enhet_cache_hit"
+const val CALL_NORG_OVERORDNET_ENHET_CACHE_MISS = "${METRICS_NS}_call_norg_overordnet_enhet_cache_miss"
+const val CALL_NORG_UNDERORDNET_ENHET_CACHE_HIT = "${METRICS_NS}_call_norg_underordnet_enhet_cache_hit"
+const val CALL_NORG_UNDERORDNET_ENHET_CACHE_MISS = "${METRICS_NS}_call_norg_underordnet_enhet_cache_miss"
 
 val COUNT_CALL_NORG_ARBEIDSFORDELING_SUCCESS: Counter = builder(CALL_NORG_ARBEIDSFORDELING_SUCCESS)
     .description("Counts the number of successful calls to Norg - Arbeidsfordeling")
@@ -15,4 +23,36 @@ val COUNT_CALL_NORG_ARBEIDSFORDELING_SUCCESS: Counter = builder(CALL_NORG_ARBEID
 
 val COUNT_CALL_NORG_ARBEIDSFORDELING_FAIL: Counter = builder(CALL_NORG_ARBEIDSFORDELING_FAIL)
     .description("Counts the number of failed calls to Norg - Arbeidsfordeling")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_NORG_ENHET_CACHE_HIT: Counter = builder(CALL_NORG_ENHET_CACHE_HIT)
+    .description("Counts the number of cache hits for NorgEnhet")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_NORG_ENHET_CACHE_MISS: Counter = builder(CALL_NORG_ENHET_CACHE_MISS)
+    .description("Counts the number of cache miss for NorgEnhet")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_HIT: Counter = builder(CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_HIT)
+    .description("Counts the number of cache hits for NorgArbeidsfordelingEnhet")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_MISS: Counter = builder(CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_MISS)
+    .description("Counts the number of cache miss for NorgArbeidsfordelingEnhet")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_NORG_OVERORDNET_ENHET_CACHE_HIT: Counter = builder(CALL_NORG_OVERORDNET_ENHET_CACHE_HIT)
+    .description("Counts the number of cache hits for overordnet enhet")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_NORG_OVERORDNET_ENHET_CACHE_MISS: Counter = builder(CALL_NORG_OVERORDNET_ENHET_CACHE_MISS)
+    .description("Counts the number of cache miss for overordnet enhet")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_NORG_UNDERORDNET_ENHET_CACHE_HIT: Counter = builder(CALL_NORG_UNDERORDNET_ENHET_CACHE_HIT)
+    .description("Counts the number of cache hits for underordnet enheter")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_NORG_UNDERORDNET_ENHET_CACHE_MISS: Counter = builder(CALL_NORG_UNDERORDNET_ENHET_CACHE_MISS)
+    .description("Counts the number of cache miss for underordnet enheter")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClientMetric.kt
@@ -10,8 +10,6 @@ const val CALL_NORG_ARBEIDSFORDELING_SUCCESS = "${CALL_NORG_ARBEIDSFORDELING_BAS
 const val CALL_NORG_ARBEIDSFORDELING_FAIL = "${CALL_NORG_ARBEIDSFORDELING_BASE}_fail_count"
 const val CALL_NORG_ENHET_CACHE_HIT = "${METRICS_NS}_call_norg_enhet_cache_hit"
 const val CALL_NORG_ENHET_CACHE_MISS = "${METRICS_NS}_call_norg_enhet_cache_miss"
-const val CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_HIT = "${METRICS_NS}_call_norg_arbeidsfordeling_enhet_cache_hit"
-const val CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_MISS = "${METRICS_NS}_call_norg_arbeidsfordeling_enhet_cache_miss"
 const val CALL_NORG_OVERORDNET_ENHET_CACHE_HIT = "${METRICS_NS}_call_norg_overordnet_enhet_cache_hit"
 const val CALL_NORG_OVERORDNET_ENHET_CACHE_MISS = "${METRICS_NS}_call_norg_overordnet_enhet_cache_miss"
 const val CALL_NORG_UNDERORDNET_ENHET_CACHE_HIT = "${METRICS_NS}_call_norg_underordnet_enhet_cache_hit"
@@ -31,14 +29,6 @@ val COUNT_CALL_NORG_ENHET_CACHE_HIT: Counter = builder(CALL_NORG_ENHET_CACHE_HIT
 
 val COUNT_CALL_NORG_ENHET_CACHE_MISS: Counter = builder(CALL_NORG_ENHET_CACHE_MISS)
     .description("Counts the number of cache miss for NorgEnhet")
-    .register(METRICS_REGISTRY)
-
-val COUNT_CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_HIT: Counter = builder(CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_HIT)
-    .description("Counts the number of cache hits for NorgArbeidsfordelingEnhet")
-    .register(METRICS_REGISTRY)
-
-val COUNT_CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_MISS: Counter = builder(CALL_NORG_ARBEIDSFORDELING_ENHET_CACHE_MISS)
-    .description("Counts the number of cache miss for NorgArbeidsfordelingEnhet")
     .register(METRICS_REGISTRY)
 
 val COUNT_CALL_NORG_OVERORDNET_ENHET_CACHE_HIT: Counter = builder(CALL_NORG_OVERORDNET_ENHET_CACHE_HIT)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/domain/RsOrganisering.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/domain/RsOrganisering.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.infrastructure.client.norg.domain
+
+data class RsOrganisering(
+    var orgType: String,
+    var organiserer: RsSimpleEnhet,
+    var organisertUnder: RsSimpleEnhet,
+    var gyldigFra: String?,
+    var gyldigTil: String?,
+)
+
+data class RsSimpleEnhet(
+    var nr: String,
+    var navn: String,
+)

--- a/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiSpek.kt
@@ -24,6 +24,7 @@ import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_NO_ACCESS
 import no.nav.syfo.testhelper.generator.generateBehandlendeEnhetDTO
 import no.nav.syfo.testhelper.mock.ENHET_NR
+import no.nav.syfo.testhelper.mock.UNDERORDNET_NR
 import no.nav.syfo.testhelper.mock.norg2Response
 import no.nav.syfo.testhelper.mock.norg2ResponseNavUtland
 import no.nav.syfo.util.*
@@ -68,6 +69,7 @@ class BehandlendeEnhetApiSpek : Spek({
 
     val behandlendeEnhetUrl = "$internadBehandlendeEnhetApiV2BasePath$internadBehandlendeEnhetApiV2PersonIdentPath"
     val personUrl = "$internadBehandlendeEnhetApiV2BasePath$internadBehandlendeEnhetApiV2PersonPath"
+    val tilordningsenheterUrl = "$internadBehandlendeEnhetApiV2BasePath$internadBehandlendeEnhetApiV2TilordningsenheterPath".replace("{$ENHET_ID_PARAM}", "1234")
     val behandlendeEnhetDTO = generateBehandlendeEnhetDTO()
     val validToken = generateJWT(
         audience = externalMockEnvironment.environment.azureAppClientId,
@@ -340,6 +342,24 @@ class BehandlendeEnhetApiSpek : Spek({
                         setBody(behandlendeEnhetDTO.copy(personident = ARBEIDSTAKER_EGENANSATT.value))
                     }
                     response.status shouldBeEqualTo HttpStatusCode.BadRequest
+                }
+            }
+        }
+    }
+    describe("Get mulige oppfolgingsenheter") {
+        describe("Happy path") {
+            it("Get mulige oppfolgingsenheter") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val response = client.get(tilordningsenheterUrl) {
+                        bearerAuth(validToken)
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.OK
+                    val behandlendeEnhetList = response.body<List<BehandlendeEnhet>>()
+
+                    behandlendeEnhetList.size shouldBeEqualTo 2
+                    behandlendeEnhetList[0].enhetId shouldBeEqualTo UNDERORDNET_NR
+                    behandlendeEnhetList[1].enhetId shouldBeEqualTo ENHET_NR
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -43,6 +43,7 @@ fun Application.testApiModule(
 
     val norgClient = NorgClient(
         baseUrl = externalMockEnvironment.environment.norg2Url,
+        valkeyStore = valkeyStore,
         httpClient = externalMockEnvironment.mockHttpClient,
     )
 


### PR DESCRIPTION
Legger til api for å hente aktuelle enheter fra samme "fylke" som en gitt enhet. Dette skal altså brukes for å lage en liste med enheter som veileder kan velge blant når de skal flytte en arbeidstaker til en annen enhet.