### PR TITLE
IS-3142: Add oppfolgingsenhet to kafka record produced when oppfolgin…

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -12,7 +12,7 @@ import no.nav.syfo.infrastructure.cache.ValkeyStore
 import no.nav.syfo.infrastructure.database.applicationDatabase
 import no.nav.syfo.infrastructure.database.databaseModule
 import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetProducer
-import no.nav.syfo.behandlendeenhet.kafka.KBehandlendeEnhetUpdate
+import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetUpdateRecord
 import no.nav.syfo.behandlendeenhet.kafka.kafkaBehandlendeEnhetProducerConfig
 import no.nav.syfo.infrastructure.client.azuread.AzureAdClient
 import no.nav.syfo.infrastructure.client.norg.NorgClient
@@ -40,7 +40,7 @@ fun main() {
     )
 
     val behandlendeEnhetProducer = BehandlendeEnhetProducer(
-        kafkaProducerBehandlendeEnhet = KafkaProducer<String, KBehandlendeEnhetUpdate>(
+        producer = KafkaProducer<String, BehandlendeEnhetUpdateRecord>(
             kafkaBehandlendeEnhetProducerConfig(environment.kafka)
         ),
     )

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
@@ -16,13 +16,12 @@ import org.slf4j.LoggerFactory
 
 const val internadBehandlendeEnhetApiV2BasePath = "/api/internad/v2"
 const val internadBehandlendeEnhetApiV2PersonIdentPath = "/personident"
-const val internadBehandlendeEnhetApiV2PersonPath = "/person"
 
 private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.behandlendeenhet.api.internad")
 
 fun Route.registrerPersonApi(
     enhetService: EnhetService,
-    veilederTilgangskontrollClient: VeilederTilgangskontrollClient
+    veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
 ) {
     route(internadBehandlendeEnhetApiV2BasePath) {
         get(internadBehandlendeEnhetApiV2PersonIdentPath) {
@@ -49,7 +48,7 @@ fun Route.registrerPersonApi(
             } ?: call.respond(HttpStatusCode.NoContent)
         }
 
-        post(internadBehandlendeEnhetApiV2PersonPath) {
+        post("/person") {
             val callId = getCallId()
             val token = getBearerHeader()
                 ?: throw IllegalArgumentException("Could not retrieve Person: No Authorization header supplied")

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/kafka/BehandlendeEnhetProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/kafka/BehandlendeEnhetProducer.kt
@@ -8,7 +8,7 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class BehandlendeEnhetProducer(
-    private val kafkaProducerBehandlendeEnhet: KafkaProducer<String, KBehandlendeEnhetUpdate>,
+    private val producer: KafkaProducer<String, BehandlendeEnhetUpdateRecord>,
 ) {
     fun sendBehandlendeEnhetUpdate(
         oppfolgingsenhet: Oppfolgingsenhet,
@@ -16,13 +16,14 @@ class BehandlendeEnhetProducer(
     ) {
         val key = UUID.nameUUIDFromBytes(oppfolgingsenhet.personident.value.toByteArray()).toString()
         try {
-            kafkaProducerBehandlendeEnhet.send(
+            producer.send(
                 ProducerRecord(
-                    BEHANDLENDE_ENHET_UPDATE_TOPIC,
+                    TOPIC,
                     key,
-                    KBehandlendeEnhetUpdate(
-                        oppfolgingsenhet.personident.value,
-                        updatedAt,
+                    BehandlendeEnhetUpdateRecord(
+                        personident = oppfolgingsenhet.personident.value,
+                        oppfolgingsenhet = oppfolgingsenhet.enhet?.value,
+                        updatedAt = updatedAt,
                     ),
                 )
             ).also { it.get() }
@@ -41,7 +42,7 @@ class BehandlendeEnhetProducer(
     }
 
     companion object {
-        const val BEHANDLENDE_ENHET_UPDATE_TOPIC = "teamsykefravr.behandlendeenhet"
+        private const val TOPIC = "teamsykefravr.behandlendeenhet"
         private val log = LoggerFactory.getLogger(BehandlendeEnhetProducer::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/kafka/BehandlendeEnhetUpdateRecord.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/kafka/BehandlendeEnhetUpdateRecord.kt
@@ -2,7 +2,8 @@ package no.nav.syfo.behandlendeenhet.kafka
 
 import java.time.OffsetDateTime
 
-data class KBehandlendeEnhetUpdate(
+data class BehandlendeEnhetUpdateRecord(
     val personident: String,
+    val oppfolgingsenhet: String?,
     val updatedAt: OffsetDateTime,
 )


### PR DESCRIPTION
⚠️ Mulig denne PR'en bare kan slettes. Det gjøres allerede et GET kall i `syfooversiktsrv` når man skal oppdatere `tildelt_enhet` ⚠️

Se [tilhørende PR](https://github.com/navikt/syfooversiktsrv/pull/527) i `syfooversiktsrv`


- Legger til `oppfolgingsenhet` i kafka record som blir sendt på topic når oppfølgingsenhet blir oppdatert.
- Videre skal denne konsumeres i `syfooversiktsrv` for å så oppdatere rad i databasen der som sier noe om oppfølgingsenheten til den sykmeldte

Lurte også på om dette egentlig er nødvendig og om vi heller burde legge til rette for et GET kall når `syfooversiktsrv` får beskjed om at oppfølgingsenhet er oppdatert 🤔 Hva tenker dere blir riktigst? 😊
EDIT: Jeg ser at vi allerede gjør et GET kall i `syfooversiktsrv` i `PersonBehandlendeEnhetService` når vi skal oppdatere behandlende enhet. Jeg tenker egentlig at det blir mest riktig slik det er 
🤔

Jeg begynte også å tenke på hvordan vi teknisk skal håndtere når sykmeldt flyttes fra en oppfølgingsenhet og tilbake til geografisk 🤔 Har noen gjort seg opp noen tanker om det? 

Kommer tilhørende PR i `syfooversiktsrv`…