### PR TITLE
IS-3146: Add syfooversikt to inbound

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -37,23 +37,12 @@ spec:
     inbound:
       rules:
         - application: isdialogmote
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: syfomodiaperson
-          namespace: teamsykefravr
-          cluster: dev-gcp
-        - application: syfomotebehov
-          namespace: team-esyfo
-          cluster: dev-fss
-        - application: syfomotebehov
-          namespace: team-esyfo
-          cluster: dev-gcp
+        - application: syfooversikt
         - application: syfooversiktsrv
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: istilgangskontroll
-          namespace: teamsykefravr
-          cluster: dev-gcp
+        - application: syfomotebehov
+          namespace: team-esyfo
         - application: meroppfolging-backend
           namespace: team-esyfo
     outbound:

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -37,23 +37,12 @@ spec:
     inbound:
       rules:
         - application: isdialogmote
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: syfomodiaperson
-          namespace: teamsykefravr
-          cluster: prod-gcp
-        - application: syfomotebehov
-          namespace: team-esyfo
-          cluster: prod-fss
-        - application: syfomotebehov
-          namespace: team-esyfo
-          cluster: prod-gcp
+        - application: syfooversikt
         - application: syfooversiktsrv
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: istilgangskontroll
-          namespace: teamsykefravr
-          cluster: prod-gcp
+        - application: syfomotebehov
+          namespace: team-esyfo
         - application: meroppfolging-backend
           namespace: team-esyfo
     outbound:


### PR DESCRIPTION
- Legger til `syfooversikt` til inbound
- Fjerner `namespace` og `cluster` fra en del av appene som er lagt inn i `inbound`. Utifra [denne](https://doc.nais.io/workloads/application/explanations/expose/?h=service+discovery#service-discovery) ser det ut som de finner dem så lenge de er i samme namespace. Kan være jeg misforstår her og dette bare gjelder for outbound 🤔