### PR TITLE
IS-3196: Add post endpoint for updating multiple oppfolgingsenheter

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetDTO.kt
@@ -5,3 +5,13 @@ data class BehandlendeEnhetDTO(
     val isNavUtland: Boolean,
     val oppfolgingsenhet: String? = null,
 )
+
+data class TildelOppfolgingsenhetRequestDTO(
+    val personidenter: List<String>,
+    val oppfolgingsenhet: String,
+)
+
+data class TildelOppfolgingsenhetResponseDTO(
+    val personident: String,
+    val oppfolgingsenhet: String?,
+)

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetDTO.kt
@@ -12,6 +12,17 @@ data class TildelOppfolgingsenhetRequestDTO(
 )
 
 data class TildelOppfolgingsenhetResponseDTO(
+    val tildelinger: List<TildelOppfolgingsenhetDTO>,
+    val errors: List<ErrorDTO>,
+)
+
+data class TildelOppfolgingsenhetDTO(
     val personident: String,
     val oppfolgingsenhet: String?,
+)
+
+data class ErrorDTO(
+    val personident: String,
+    val errorMessage: String? = null,
+    val errorCode: Int? = null,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClientMetric.kt
@@ -9,6 +9,11 @@ const val CALL_TILGANGSKONTROLL_SYFO_SUCCESS = "${CALL_TILGANGSKONTROLL_SYFO_BAS
 const val CALL_TILGANGSKONTROLL_SYFO_FAIL = "${CALL_TILGANGSKONTROLL_SYFO_BASE}_fail_count"
 const val CALL_TILGANGSKONTROLL_SYFO_FORBIDDEN = "${CALL_TILGANGSKONTROLL_SYFO_BASE}_forbidden_count"
 
+const val CALL_TILGANGSKONTROLL_BRUKERE_BASE = "${METRICS_NS}_call_tilgangskontroll_brukere"
+const val CALL_TILGANGSKONTROLL_BRUKERE_SUCCESS = "${CALL_TILGANGSKONTROLL_BRUKERE_BASE}_success_count"
+const val CALL_TILGANGSKONTROLL_BRUKERE_FAIL = "${CALL_TILGANGSKONTROLL_BRUKERE_BASE}_fail_count"
+const val CALL_TILGANGSKONTROLL_BRUKERE_FORBIDDEN = "${CALL_TILGANGSKONTROLL_BRUKERE_BASE}_forbidden_count"
+
 val COUNT_CALL_TILGANGSKONTROLL_SYFO_SUCCESS: Counter = Counter.builder(CALL_TILGANGSKONTROLL_SYFO_SUCCESS)
     .description("Counts the number of successful calls to istilgangskontroll - person")
     .register(METRICS_REGISTRY)
@@ -17,4 +22,14 @@ val COUNT_CALL_TILGANGSKONTROLL_SYFO_FAIL: Counter = Counter.builder(CALL_TILGAN
     .register(METRICS_REGISTRY)
 val COUNT_CALL_TILGANGSKONTROLL_SYFO_FORBIDDEN: Counter = Counter.builder(CALL_TILGANGSKONTROLL_SYFO_FORBIDDEN)
     .description("Counts the number of forbidden calls to istilgangskontroll - person")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_TILGANGSKONTROLL_BRUKERE_SUCCESS: Counter = Counter.builder(CALL_TILGANGSKONTROLL_BRUKERE_SUCCESS)
+    .description("Counts the number of successful calls to istilgangskontroll - /brukere")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_TILGANGSKONTROLL_BRUKERE_FAIL: Counter = Counter.builder(CALL_TILGANGSKONTROLL_BRUKERE_FAIL)
+    .description("Counts the number of failed calls to istilgangskontroll - /brukere")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_TILGANGSKONTROLL_BRUKERE_FORBIDDEN: Counter = Counter.builder(CALL_TILGANGSKONTROLL_BRUKERE_FORBIDDEN)
+    .description("Counts the number of forbidden calls to istilgangskontroll - /brukere")
     .register(METRICS_REGISTRY)

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -14,4 +14,5 @@ object UserConstants {
     val VEILEDER_IDENT_NO_ACCESS = VEILEDER_IDENT.replace("9", "1")
 
     const val ENHET_ID = "0314"
+    const val OTHER_ENHET_ID = "0414"
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/GenerateOppfolgingsenhet.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/GenerateOppfolgingsenhet.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.testhelper.generator
 
 import no.nav.syfo.behandlendeenhet.api.BehandlendeEnhetDTO
+import no.nav.syfo.behandlendeenhet.api.TildelOppfolgingsenhetRequestDTO
 import no.nav.syfo.domain.EnhetId.Companion.ENHETNR_NAV_UTLAND
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 
@@ -12,4 +13,12 @@ fun generateBehandlendeEnhetDTO(
     personident = personident,
     isNavUtland = isNavUtland,
     oppfolgingsenhet = if (isNavUtland) ENHETNR_NAV_UTLAND else oppfolgingsenhet,
+)
+
+fun generateTildelOppfolgingsenhetRequestDTO(
+    personidenter: List<String> = listOf(ARBEIDSTAKER_PERSONIDENT.value),
+    oppfolgingsenhet: String,
+) = TildelOppfolgingsenhetRequestDTO(
+    personidenter = personidenter,
+    oppfolgingsenhet = oppfolgingsenhet,
 )

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
@@ -4,15 +4,16 @@ import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import no.nav.syfo.infrastructure.client.norg.NorgClient.Companion.ENHET_TYPE_LOKAL
 import no.nav.syfo.infrastructure.client.norg.domain.*
+import no.nav.syfo.testhelper.UserConstants.ENHET_ID
 
-const val ENHET_NR = "0101"
+const val GEOGRAFISK_ENHET_NR = "0101"
 const val OVERORDNET_NR = "0200"
 const val UNDERORDNET_NR = "0102"
 const val ENHET_NAVN = "Enhet"
 
 fun generateNorgEnhet(): NorgEnhet {
     return NorgEnhet(
-        enhetNr = ENHET_NR,
+        enhetNr = GEOGRAFISK_ENHET_NR,
         navn = ENHET_NAVN,
         status = Enhetsstatus.AKTIV.formattedName,
         aktiveringsdato = null,
@@ -33,6 +34,7 @@ fun generateNorgEnhet(): NorgEnhet {
 }
 
 val norg2Response = listOf(generateNorgEnhet())
+val norg2ResponseAnnenKommune = listOf(generateNorgEnhet().copy(enhetNr = ENHET_ID, navn = "Annen kommune"))
 val norg2ResponseNavUtland = listOf(generateNorgEnhet().copy(enhetNr = "0393", navn = "Nav utland"))
 val norg2ResponseOverordnet = listOf(generateNorgEnhet().copy(enhetNr = OVERORDNET_NR, navn = "Overordnet"))
 
@@ -42,6 +44,8 @@ suspend fun MockRequestHandleScope.getNorg2Response(request: HttpRequestData): H
         val body = request.receiveBody<ArbeidsfordelingCriteria>()
         if (body.behandlingstype == ArbeidsfordelingCriteriaBehandlingstype.NAV_UTLAND.behandlingstype) {
             respond(norg2ResponseNavUtland)
+        } else if (body.geografiskOmraade == geografiskTilknytningAnnenKommune) {
+            respond(norg2ResponseAnnenKommune)
         } else {
             respond(norg2Response)
         }
@@ -60,7 +64,7 @@ suspend fun MockRequestHandleScope.getNorg2Response(request: HttpRequestData): H
                 RsOrganisering(
                     orgType = "ENHET",
                     organiserer = RsSimpleEnhet(OVERORDNET_NR, "Overordnet"),
-                    organisertUnder = RsSimpleEnhet(ENHET_NR, ENHET_NAVN),
+                    organisertUnder = RsSimpleEnhet(GEOGRAFISK_ENHET_NR, ENHET_NAVN),
                     gyldigFra = null,
                     gyldigTil = null,
                 ),

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
@@ -2,13 +2,21 @@ package no.nav.syfo.testhelper.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
-import io.ktor.http.*
 import no.nav.syfo.infrastructure.client.pdl.PdlClient.Companion.GT_HEADER
 import no.nav.syfo.infrastructure.client.pdl.domain.*
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
 
 const val geografiskTilknytningKommune = "0330"
+const val geografiskTilknytningAnnenKommune = "0440"
+
+fun generateAnnenGeografiskTilknytningKommune() =
+    PdlGeografiskTilknytning(
+        gtType = PdlGeografiskTilknytningType.KOMMUNE.name,
+        gtBydel = null,
+        gtKommune = geografiskTilknytningAnnenKommune,
+        gtLand = null,
+    )
 
 fun generatePdlHentGeografiskTilknytning(
     hentGeografiskTilknytning: PdlGeografiskTilknytning? = PdlGeografiskTilknytning(
@@ -92,14 +100,21 @@ suspend fun MockRequestHandleScope.pdlMockResponse(request: HttpRequestData): Ht
     return if (request.headers[GT_HEADER] == GT_HEADER) {
         val pdlRequest = request.receiveBody<PdlGeografiskTilknytningRequest>()
         when (pdlRequest.variables.ident) {
-            UserConstants.ARBEIDSTAKER_PERSONIDENT.value -> {
-                respond(generatePdlGeografiskTilknytningResponse())
-            }
             UserConstants.ARBEIDSTAKER_GEOGRAFISK_TILKNYTNING_NOT_FOUND.value -> {
                 respond(generatePdlGeografiskTilknytningNotFoundResponse())
             }
+            UserConstants.ARBEIDSTAKER_PERSONIDENT_3.value -> {
+                respond(
+                    PdlGeografiskTilknytningResponse(
+                        data = PdlHentGeografiskTilknytning(
+                            hentGeografiskTilknytning = generateAnnenGeografiskTilknytningKommune()
+                        ),
+                        errors = emptyList(),
+                    )
+                )
+            }
             else -> {
-                respond(HttpStatusCode.InternalServerError)
+                respond(generatePdlGeografiskTilknytningResponse())
             }
         }
     } else {

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
@@ -6,6 +6,9 @@ import io.ktor.http.*
 import no.nav.syfo.application.api.authentication.Token
 import no.nav.syfo.application.api.authentication.getNAVIdent
 import no.nav.syfo.infrastructure.client.veiledertilgang.TilgangDTO
+import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.ACCESS_TO_BRUKERE_PATH
+import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.ACCESS_TO_SYFO_PATH
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_NO_ACCESS
 
 val tilgangFalse = TilgangDTO(
@@ -16,13 +19,25 @@ val tilgangTrue = TilgangDTO(
     erGodkjent = true,
 )
 
-fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequestData): HttpResponseData {
-    val token = Token(request.headers[HttpHeaders.Authorization]?.removePrefix("Bearer ")!!)
-    val navIdent = token.getNAVIdent()
+suspend fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequestData): HttpResponseData {
+    val requestUrl = request.url.encodedPath
 
-    return if (navIdent == VEILEDER_IDENT_NO_ACCESS) {
-        respond(tilgangFalse)
-    } else {
-        respond(tilgangTrue)
+    return when {
+        requestUrl.endsWith(ACCESS_TO_SYFO_PATH) -> {
+            val token = Token(request.headers[HttpHeaders.Authorization]?.removePrefix("Bearer ")!!)
+            val navIdent = token.getNAVIdent()
+
+            return if (navIdent == VEILEDER_IDENT_NO_ACCESS) {
+                respond(tilgangFalse)
+            } else {
+                respond(tilgangTrue)
+            }
+        }
+        requestUrl.endsWith(ACCESS_TO_BRUKERE_PATH) -> {
+            val personidenter = request.receiveBody<List<String>>()
+            val personerWhereTilgangOk = personidenter.filter { it != ARBEIDSTAKER_ADRESSEBESKYTTET.value }
+            respond(personerWhereTilgangOk)
+        }
+        else -> error("Unhandled path $requestUrl")
     }
 }


### PR DESCRIPTION
Det meste av kodelinjene er tester og mocker. Bruker allerede nåværende service, så er nok det som skjer i API-laget som er mest spennende. Kom gjerne med input på path for endepunktet, DTOene og hvordan vi kan håndtere feil.

Foreløpig er det tenkt at dersom man oppdaterer 5 stk, og én av de feiler, så leverer APIet 200 OK med de 4 man oppdaterte. Samtidig er det sånn at hvis man oppdaterer 5 stk, og veileder mangler tilgang til én av de, vil man også levere 200 OK med de 4 som er oppdatert. Det er ikke så flott, kanskje.

Et alternativ er å endre responsen fra APIet til å inkludere en slags "disse gikk det bra med" og "disse feilet" i to lister 🤷🏼‍♂️