### PR TITLE
IS-3166: System-api for å nulle oppfolgingsenhet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -46,7 +46,7 @@ class EnhetService(
         callId: String,
         personIdent: PersonIdentNumber,
         enhetId: EnhetId?,
-        veilederToken: Token,
+        veilederToken: Token? = null,
     ): Oppfolgingsenhet? =
         if (validateForOppfolgingsenhet(callId, personIdent, veilederToken)) {
             val geografiskEnhet = findGeografiskEnhet(
@@ -56,8 +56,9 @@ class EnhetService(
             )
             val newBehandlendeEnhet = if (enhetId?.value != geografiskEnhet.enhetId) enhetId else null
             val currentOppfolgingsenhet = getOppfolgingsenhet(personIdent)
+            val navIdent = veilederToken?.getNAVIdent() ?: "Z999999"
             if (newBehandlendeEnhet != null || currentOppfolgingsenhet != null) {
-                repository.createOppfolgingsenhet(personIdent, newBehandlendeEnhet, veilederToken.getNAVIdent()).also {
+                repository.createOppfolgingsenhet(personIdent, newBehandlendeEnhet, navIdent).also {
                     behandlendeEnhetProducer.sendBehandlendeEnhetUpdate(it, it.createdAt)
                 }
             } else {
@@ -133,7 +134,7 @@ class EnhetService(
     private suspend fun validateForOppfolgingsenhet(
         callId: String,
         personIdent: PersonIdentNumber,
-        veilederToken: Token,
+        veilederToken: Token?,
     ): Boolean {
         val isEgenAnsatt = skjermedePersonerPipClient.isSkjermet(
             callId = callId,

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -56,7 +56,7 @@ class EnhetService(
             )
             val newBehandlendeEnhet = if (enhetId?.value != geografiskEnhet.enhetId) enhetId else null
             val currentOppfolgingsenhet = getOppfolgingsenhet(personIdent)
-            val navIdent = veilederToken?.getNAVIdent() ?: "Z999999"
+            val navIdent = veilederToken?.getNAVIdent() ?: SYSTEM_USER_IDENT
             if (newBehandlendeEnhet != null || currentOppfolgingsenhet != null) {
                 repository.createOppfolgingsenhet(personIdent, newBehandlendeEnhet, navIdent).also {
                     behandlendeEnhetProducer.sendBehandlendeEnhetUpdate(it, it.createdAt)
@@ -174,6 +174,7 @@ class EnhetService(
     companion object {
         private const val GEOGRAFISK_TILKNYTNING_UTVANDRET = "NOR"
         private const val ENHETSNAVN_MANGLER = "Enhetsnavn mangler"
+        const val SYSTEM_USER_IDENT = "Z999999"
         const val CACHE_GEOGRAFISKENHET_PERSONIDENT_KEY_PREFIX = "geografiskenhet-personident-"
         const val CACHE_GEOGRAFISKENHET_PERSONIDENT_EXPIRE_SECONDS = 12 * 60 * 60L
     }

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemAPI.kt
@@ -41,5 +41,27 @@ fun Route.registrerSystemApi(
                 .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) ?: HttpStatusCode.NoContent }
                 .run { call.respond(this) }
         }
+        post(systemdBehandlendeEnhetApiV2PersonIdentPath) {
+            val callId = getCallId()
+            val token = getBearerHeader()
+                ?: throw IllegalArgumentException("Could not retrieve Person: No Authorization header supplied")
+
+            apiConsumerAccessService.validateConsumerApplicationAZP(
+                authorizedApplicationNameList = authorizedApplicationNameList,
+                token = token,
+            )
+
+            val personIdentNumber = personIdentHeader()?.let { personIdent ->
+                PersonIdentNumber(personIdent)
+            }
+                ?: throw IllegalArgumentException("Could not set BehandlendeEnhet: No $NAV_PERSONIDENT_HEADER supplied in request header")
+
+            enhetService.updateOppfolgingsenhet(
+                callId = callId,
+                personIdent = personIdentNumber,
+                enhetId = null,
+            )
+            call.respond(HttpStatusCode.OK)
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemAPI.kt
@@ -44,7 +44,7 @@ fun Route.registrerSystemApi(
         post(systemdBehandlendeEnhetApiV2PersonIdentPath) {
             val callId = getCallId()
             val token = getBearerHeader()
-                ?: throw IllegalArgumentException("Could not retrieve Person: No Authorization header supplied")
+                ?: throw IllegalArgumentException("Could not set BehandlendeEnhet: No Authorization header supplied")
 
             apiConsumerAccessService.validateConsumerApplicationAZP(
                 authorizedApplicationNameList = authorizedApplicationNameList,

--- a/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemApiSpek.kt
@@ -11,6 +11,8 @@ import io.mockk.justRun
 import io.mockk.mockk
 import no.nav.syfo.behandlendeenhet.api.BehandlendeEnhetResponseDTO
 import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetProducer
+import no.nav.syfo.domain.EnhetId
+import no.nav.syfo.infrastructure.database.repository.EnhetRepository
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.mock.norg2Response
 import no.nav.syfo.util.*
@@ -21,6 +23,7 @@ import org.spekframework.spek2.style.specification.describe
 class BehandlendeEnhetSystemApiSpek : Spek({
     describe(BehandlendeEnhetSystemApiSpek::class.java.simpleName) {
         val externalMockEnvironment = ExternalMockEnvironment.instance
+        val repository = EnhetRepository(externalMockEnvironment.database)
 
         val behandlendeEnhetProducer = mockk<BehandlendeEnhetProducer>()
         justRun { behandlendeEnhetProducer.sendBehandlendeEnhetUpdate(any(), any()) }
@@ -42,7 +45,7 @@ class BehandlendeEnhetSystemApiSpek : Spek({
 
         val url = "$systemBehandlendeEnhetApiV2BasePath$systemdBehandlendeEnhetApiV2PersonIdentPath"
 
-        describe("Get BehandlendeEnhet for PersonIdent as System") {
+        describe("Get/Post BehandlendeEnhet for PersonIdent as System") {
             describe("Happy path") {
                 externalMockEnvironment.environment.systemAPIAuthorizedConsumerApplicationNameList.forEach { consumerApplicationName ->
 
@@ -72,6 +75,57 @@ class BehandlendeEnhetSystemApiSpek : Spek({
                             behandlendeEnhet.geografiskEnhet.navn shouldBeEqualTo "Enhet"
                             behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo "0101"
                             behandlendeEnhet.oppfolgingsenhet.navn shouldBeEqualTo "Enhet"
+                        }
+                    }
+                    it("Post BehandlendeEnhet for PersonIdent as $consumerApplicationName") {
+                        testApplication {
+                            val client = setupApiAndClient()
+                            val responsePost = client.post(url) {
+                                bearerAuth(validToken)
+                                header(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
+                            }
+                            responsePost.status shouldBeEqualTo HttpStatusCode.OK
+
+                            val response = client.get(url) {
+                                bearerAuth(validToken)
+                                header(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
+                            }
+                            response.status shouldBeEqualTo HttpStatusCode.OK
+                            val behandlendeEnhet = response.body<BehandlendeEnhetResponseDTO>()
+                            behandlendeEnhet.geografiskEnhet.enhetId shouldBeEqualTo "0101"
+                            behandlendeEnhet.geografiskEnhet.navn shouldBeEqualTo "Enhet"
+                            behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo "0101"
+                        }
+                    }
+                    it("Post BehandlendeEnhet for PersonIdent which has oppfolgingsenhet as $consumerApplicationName") {
+                        testApplication {
+                            val client = setupApiAndClient()
+                            repository.createOppfolgingsenhet(
+                                personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+                                enhetId = EnhetId("0102"),
+                                veilederident = "Z999999",
+                            )
+                            val responsePre = client.get(url) {
+                                bearerAuth(validToken)
+                                header(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
+                            }
+                            responsePre.status shouldBeEqualTo HttpStatusCode.OK
+                            val behandlendeEnhetPre = responsePre.body<BehandlendeEnhetResponseDTO>()
+                            behandlendeEnhetPre.oppfolgingsenhet.enhetId shouldBeEqualTo "0102"
+
+                            val responsePost = client.post(url) {
+                                bearerAuth(validToken)
+                                header(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
+                            }
+                            responsePost.status shouldBeEqualTo HttpStatusCode.OK
+
+                            val response = client.get(url) {
+                                bearerAuth(validToken)
+                                header(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
+                            }
+                            response.status shouldBeEqualTo HttpStatusCode.OK
+                            val behandlendeEnhet = response.body<BehandlendeEnhetResponseDTO>()
+                            behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo "0101"
                         }
                     }
 

--- a/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemApiSpek.kt
@@ -103,7 +103,7 @@ class BehandlendeEnhetSystemApiSpek : Spek({
                             repository.createOppfolgingsenhet(
                                 personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
                                 enhetId = EnhetId("0102"),
-                                veilederident = "Z999999",
+                                veilederident = UserConstants.VEILEDER_IDENT,
                             )
                             val responsePre = client.get(url) {
                                 bearerAuth(validToken)
@@ -119,12 +119,12 @@ class BehandlendeEnhetSystemApiSpek : Spek({
                             }
                             responsePost.status shouldBeEqualTo HttpStatusCode.OK
 
-                            val response = client.get(url) {
+                            val responseGet = client.get(url) {
                                 bearerAuth(validToken)
                                 header(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
                             }
-                            response.status shouldBeEqualTo HttpStatusCode.OK
-                            val behandlendeEnhet = response.body<BehandlendeEnhetResponseDTO>()
+                            responseGet.status shouldBeEqualTo HttpStatusCode.OK
+                            val behandlendeEnhet = responseGet.body<BehandlendeEnhetResponseDTO>()
                             behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo "0101"
                         }
                     }


### PR DESCRIPTION
Vi må nulle oppfølgingsenhet samtidig som vi nuller tildelt veileder (det vil si: for personer som ikke lengre skal følges opp i Modia). Nullingen skal skje fra `syfooversiktsrv`, men trenger et endepunkt slik at vi kan gjøre det med system-token.