### PR TITLE
IS-3238: Remove duplicate kontor from Norg-kall

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
@@ -185,6 +185,7 @@ class NorgClient(
                 }
                 response
                     .mapNotNull { it.organisertUnder?.nr }
+                    .distinct()
                     .mapNotNull { getNorgEnhet(it) }
                     .filter { it.type == ENHET_TYPE_LOKAL && it.status == Enhetsstatus.AKTIV.formattedName }
             } catch (e: ResponseException) {

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
@@ -64,6 +64,13 @@ suspend fun MockRequestHandleScope.getNorg2Response(request: HttpRequestData): H
                 RsOrganisering(
                     orgType = "ENHET",
                     organiserer = RsSimpleEnhet(OVERORDNET_NR, "Overordnet"),
+                    organisertUnder = RsSimpleEnhet(UNDERORDNET_NR, "Underordnet"),
+                    gyldigFra = null,
+                    gyldigTil = null,
+                ),
+                RsOrganisering(
+                    orgType = "ENHET",
+                    organiserer = RsSimpleEnhet(OVERORDNET_NR, "Overordnet"),
                     organisertUnder = RsSimpleEnhet(GEOGRAFISK_ENHET_NR, ENHET_NAVN),
                     gyldigFra = null,
                     gyldigTil = null,


### PR DESCRIPTION
Det ser ut til at vi får en liste med duplikat-kontor fra backenden når vi skal populere dropdownen for å velge oppfølgingsenhet. En antakelse er at Norg leverer kontorene flere ganger, så vi prøver å kjøre `distinct` på lista for å unngå dette.

Eksempel: Bodø kommer flere ganger i denne lista.
![image](https://github.com/user-attachments/assets/930a1179-aee1-4f1e-9a70-44a10db0a50e)
