### PR TITLE
Revert "IS-3263: Remove unused post-endpoint for tildeling oppfolgingsenhet for one person"

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetDTO.kt
@@ -1,5 +1,11 @@
 package no.nav.syfo.behandlendeenhet.api
 
+data class BehandlendeEnhetDTO(
+    val personident: String,
+    val isNavUtland: Boolean,
+    val oppfolgingsenhet: String? = null,
+)
+
 data class TildelOppfolgingsenhetRequestDTO(
     val personidenter: List<String>,
     val oppfolgingsenhet: String,

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetResponseDTO.kt
@@ -4,6 +4,10 @@ import no.nav.syfo.behandlendeenhet.Enhet
 import no.nav.syfo.domain.BehandlendeEnhet
 
 data class BehandlendeEnhetResponseDTO(
+    @Deprecated("Erstattet av geografisk enhet og oppfolgingsenhet")
+    val enhetId: String,
+    @Deprecated("Erstattet av geografisk enhet og oppfolgingsenhet")
+    val navn: String,
     val geografiskEnhet: Enhet,
     val oppfolgingsenhet: Enhet,
 ) {
@@ -12,6 +16,8 @@ data class BehandlendeEnhetResponseDTO(
             val oppfolgingsenhet = behandlendeEnhet.oppfolgingsenhet ?: behandlendeEnhet.geografiskEnhet
 
             return BehandlendeEnhetResponseDTO(
+                enhetId = oppfolgingsenhet.enhetId,
+                navn = oppfolgingsenhet.navn,
                 geografiskEnhet = behandlendeEnhet.geografiskEnhet,
                 oppfolgingsenhet = oppfolgingsenhet,
             )

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
@@ -7,6 +7,7 @@ import io.ktor.server.routing.*
 import no.nav.syfo.application.api.authentication.getNAVIdent
 import no.nav.syfo.behandlendeenhet.EnhetService
 import no.nav.syfo.behandlendeenhet.api.*
+import no.nav.syfo.behandlendeenhet.domain.toBehandlendeEnhetDTO
 import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
@@ -20,6 +21,7 @@ import org.slf4j.LoggerFactory
 const val ENHET_ID_PARAM = "enhetId"
 const val internadBehandlendeEnhetApiV2BasePath = "/api/internad/v2"
 const val internadBehandlendeEnhetApiV2PersonIdentPath = "/personident"
+const val internadBehandlendeEnhetApiV2PersonPath = "/person"
 const val internadBehandlendeEnhetApiV2TilordningsenheterPath = "/tilordningsenheter/{$ENHET_ID_PARAM}"
 
 private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.behandlendeenhet.api.internad")
@@ -49,7 +51,7 @@ fun Route.registrerPersonApi(
                 personIdentNumber = personIdentNumber,
                 veilederToken = token,
             )
-                .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) }
+                .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) ?: HttpStatusCode.NoContent }
                 .run { call.respond(this) }
         }
 
@@ -69,6 +71,34 @@ fun Route.registrerPersonApi(
             val tilordningsenheter = enhetService.getMuligeOppfolgingsenheter(callId, EnhetId(enhetId), veilederident)
 
             call.respond(tilordningsenheter)
+        }
+
+        post(internadBehandlendeEnhetApiV2PersonPath) {
+            val callId = getCallId()
+            val token = getBearerHeader()
+                ?: throw IllegalArgumentException("Could not retrieve Person: No Authorization header supplied")
+
+            veilederTilgangskontrollClient.throwExceptionIfVeilederWithoutAccessToSYFOWithOBO(
+                callId = callId,
+                token = token,
+            )
+
+            val behandlendeEnhetDTO = call.receive<BehandlendeEnhetDTO>()
+
+            val oppfolgingsenhet = enhetService.updateOppfolgingsenhet(
+                callId = callId,
+                personIdent = PersonIdentNumber(behandlendeEnhetDTO.personident),
+                enhetId = behandlendeEnhetDTO.oppfolgingsenhet?.let { EnhetId(it) }
+                    ?: if (behandlendeEnhetDTO.isNavUtland) EnhetId(EnhetId.ENHETNR_NAV_UTLAND) else null,
+                veilederToken = token,
+            )
+
+            if (oppfolgingsenhet != null) {
+                call.respond(oppfolgingsenhet.toBehandlendeEnhetDTO())
+            } else {
+                log.error("Could not set oppfolgingsenhet in database")
+                call.respond(HttpStatusCode.BadRequest)
+            }
         }
 
         post("/oppfolgingsenhet-tildelinger") {

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemAPI.kt
@@ -38,7 +38,7 @@ fun Route.registrerSystemApi(
                 personIdentNumber = personIdentNumber,
                 veilederToken = null,
             )
-                .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) }
+                .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) ?: HttpStatusCode.NoContent }
                 .run { call.respond(this) }
         }
         post(systemdBehandlendeEnhetApiV2PersonIdentPath) {

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Oppfolgingsenhet.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Oppfolgingsenhet.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.behandlendeenhet.domain
 
+import no.nav.syfo.behandlendeenhet.api.BehandlendeEnhetDTO
 import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.domain.PersonIdentNumber
 import java.time.OffsetDateTime
@@ -11,4 +12,10 @@ data class Oppfolgingsenhet(
     val enhetId: EnhetId?,
     val veilederident: String,
     val createdAt: OffsetDateTime,
+)
+
+fun Oppfolgingsenhet.toBehandlendeEnhetDTO() = BehandlendeEnhetDTO(
+    personident = this.personident.value,
+    isNavUtland = this.enhetId?.isNavUtland() ?: false,
+    oppfolgingsenhet = this.enhetId?.value,
 )

--- a/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiSpek.kt
@@ -9,9 +9,11 @@ import io.ktor.serialization.jackson.*
 import io.ktor.server.testing.*
 import io.mockk.clearMocks
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
-import no.nav.syfo.behandlendeenhet.Enhet
 import no.nav.syfo.behandlendeenhet.api.BehandlendeEnhetResponseDTO
+import no.nav.syfo.behandlendeenhet.Enhet
+import no.nav.syfo.behandlendeenhet.api.BehandlendeEnhetDTO
 import no.nav.syfo.behandlendeenhet.api.TildelOppfolgingsenhetResponseDTO
 import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetProducer
 import no.nav.syfo.behandlendeenhet.kafka.KBehandlendeEnhetUpdate
@@ -30,15 +32,17 @@ import no.nav.syfo.testhelper.UserConstants.ENHET_ID
 import no.nav.syfo.testhelper.UserConstants.OTHER_ENHET_ID
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_NO_ACCESS
+import no.nav.syfo.testhelper.generator.generateBehandlendeEnhetDTO
 import no.nav.syfo.testhelper.generator.generateTildelOppfolgingsenhetRequestDTO
-import no.nav.syfo.testhelper.mock.GEOGRAFISK_ENHET_NR
-import no.nav.syfo.testhelper.mock.GEOGRAFISK_ENHET_NR_2
-import no.nav.syfo.testhelper.mock.UNDERORDNET_NR
+import no.nav.syfo.testhelper.mock.*
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.configure
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeLessThan
 import org.amshove.kluent.shouldNotBe
 import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -74,8 +78,10 @@ class BehandlendeEnhetApiSpek : Spek({
     }
 
     val behandlendeEnhetUrl = "$internadBehandlendeEnhetApiV2BasePath$internadBehandlendeEnhetApiV2PersonIdentPath"
+    val personUrl = "$internadBehandlendeEnhetApiV2BasePath$internadBehandlendeEnhetApiV2PersonPath"
     val oppfolgingsenhetTildelingerUrl = "$internadBehandlendeEnhetApiV2BasePath/oppfolgingsenhet-tildelinger"
     val tilordningsenheterUrl = "$internadBehandlendeEnhetApiV2BasePath$internadBehandlendeEnhetApiV2TilordningsenheterPath".replace("{$ENHET_ID_PARAM}", GEOGRAFISK_ENHET_NR)
+    val behandlendeEnhetDTO = generateBehandlendeEnhetDTO()
     val validToken = generateJWT(
         audience = externalMockEnvironment.environment.azureAppClientId,
         issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
@@ -94,6 +100,8 @@ class BehandlendeEnhetApiSpek : Spek({
                     response.status shouldBeEqualTo HttpStatusCode.OK
                     val behandlendeEnhet = response.body<BehandlendeEnhetResponseDTO>()
 
+                    behandlendeEnhet.enhetId shouldBeEqualTo norg2Response.first().enhetNr
+                    behandlendeEnhet.navn shouldBeEqualTo norg2Response.first().navn
                     behandlendeEnhet.geografiskEnhet.enhetId shouldBeEqualTo "0101"
                     behandlendeEnhet.geografiskEnhet.navn shouldBeEqualTo "Enhet"
                     behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo "0101"
@@ -109,6 +117,31 @@ class BehandlendeEnhetApiSpek : Spek({
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_GEOGRAFISK_TILKNYTNING_NOT_FOUND.value)
                     }
                     response.status shouldBeEqualTo HttpStatusCode.NoContent
+                }
+            }
+
+            it("should send NavUtland behandlingstype if Person has entry in database") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val responsePost = client.post(personUrl) {
+                        bearerAuth(validToken)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetDTO)
+                    }
+                    responsePost.status shouldBeEqualTo HttpStatusCode.OK
+                    val response = client.get(behandlendeEnhetUrl) {
+                        bearerAuth(validToken)
+                        header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.OK
+                    val behandlendeEnhet = response.body<BehandlendeEnhetResponseDTO>()
+
+                    behandlendeEnhet.enhetId shouldBeEqualTo norg2ResponseNavUtland.first().enhetNr
+                    behandlendeEnhet.navn shouldBeEqualTo norg2ResponseNavUtland.first().navn
+                    behandlendeEnhet.geografiskEnhet.enhetId shouldBeEqualTo "0101"
+                    behandlendeEnhet.geografiskEnhet.navn shouldBeEqualTo "Enhet"
+                    behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo "0393"
+                    behandlendeEnhet.oppfolgingsenhet.navn shouldBeEqualTo "Nav utland"
                 }
             }
         }
@@ -160,14 +193,187 @@ class BehandlendeEnhetApiSpek : Spek({
         }
     }
 
+    describe("Update oppfolgingsenhet") {
+        describe("Happy path") {
+            it("should create oppfolgingsenhet in db") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val response = client.post(personUrl) {
+                        bearerAuth(validToken)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetDTO)
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.OK
+                    response.body<BehandlendeEnhetDTO>() shouldBeEqualTo behandlendeEnhetDTO
+
+                    val oppfolgingsenhet = repository.getOppfolgingsenhetByPersonident(PersonIdentNumber(behandlendeEnhetDTO.personident))
+                    oppfolgingsenhet?.enhetId?.isNavUtland() shouldBeEqualTo true
+                    oppfolgingsenhet?.personident?.value shouldBeEqualTo behandlendeEnhetDTO.personident
+
+                    val kafkaRecordSlot = slot<ProducerRecord<String, KBehandlendeEnhetUpdate>>()
+                    verify(exactly = 1) { kafkaProducerMock.send(capture(kafkaRecordSlot)) }
+                    kafkaRecordSlot.captured.value().personident shouldBeEqualTo oppfolgingsenhet?.personident?.value
+                    kafkaRecordSlot.captured.value().updatedAt shouldBeEqualTo oppfolgingsenhet?.createdAt
+                }
+            }
+            it("should create oppfolgingsenhet other than Nav utland in db") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val behandlendeEnhetDTO = BehandlendeEnhetDTO(
+                        personident = ARBEIDSTAKER_PERSONIDENT.value,
+                        isNavUtland = false,
+                        oppfolgingsenhet = ENHET_ID,
+                    )
+                    val response = client.post(personUrl) {
+                        bearerAuth(validToken)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetDTO)
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.OK
+                    response.body<BehandlendeEnhetDTO>() shouldBeEqualTo behandlendeEnhetDTO
+
+                    val oppfolgingsenhet =
+                        repository.getOppfolgingsenhetByPersonident(PersonIdentNumber(behandlendeEnhetDTO.personident))
+                    oppfolgingsenhet?.enhetId?.isNavUtland() shouldBeEqualTo false
+                    oppfolgingsenhet?.enhetId?.value shouldBeEqualTo ENHET_ID
+                    oppfolgingsenhet?.personident?.value shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
+
+                    val kafkaRecordSlot = slot<ProducerRecord<String, KBehandlendeEnhetUpdate>>()
+                    verify(exactly = 1) { kafkaProducerMock.send(capture(kafkaRecordSlot)) }
+                    kafkaRecordSlot.captured.value().personident shouldBeEqualTo oppfolgingsenhet?.personident?.value
+                    kafkaRecordSlot.captured.value().updatedAt shouldBeEqualTo oppfolgingsenhet?.createdAt
+                }
+            }
+            it("should store null as oppfolgingsenhet if same as geografisk and current oppfolgingsenhet is not null") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val behandlendeEnhetDTO = BehandlendeEnhetDTO(
+                        personident = ARBEIDSTAKER_PERSONIDENT.value,
+                        isNavUtland = false,
+                        oppfolgingsenhet = ENHET_ID,
+                    )
+                    client.post(personUrl) {
+                        bearerAuth(validToken)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetDTO)
+                    }
+                    clearMocks(kafkaProducerMock)
+
+                    val behandlendeEnhetUpdateDTO = BehandlendeEnhetDTO(
+                        personident = ARBEIDSTAKER_PERSONIDENT.value,
+                        isNavUtland = false,
+                        oppfolgingsenhet = GEOGRAFISK_ENHET_NR, // norg2mock-value
+                    )
+                    val response = client.post(personUrl) {
+                        bearerAuth(validToken)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetUpdateDTO)
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.OK
+
+                    val oppfolgingsenhet = repository.getOppfolgingsenhetByPersonident(PersonIdentNumber(behandlendeEnhetDTO.personident))
+                    oppfolgingsenhet?.enhetId shouldBe null
+                    oppfolgingsenhet?.personident?.value shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
+
+                    val kafkaRecordSlot = slot<ProducerRecord<String, KBehandlendeEnhetUpdate>>()
+                    verify(exactly = 1) { kafkaProducerMock.send(capture(kafkaRecordSlot)) }
+                    kafkaRecordSlot.captured.value().personident shouldBeEqualTo oppfolgingsenhet?.personident?.value
+                    kafkaRecordSlot.captured.value().updatedAt shouldBeEqualTo oppfolgingsenhet?.createdAt
+                }
+            }
+
+            it("should update oppfolgingsenhet if already in db") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val response = client.post(personUrl) {
+                        bearerAuth(validToken)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetDTO)
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.OK
+                    val oppfolgingsenhet = repository.getOppfolgingsenhetByPersonident(PersonIdentNumber(behandlendeEnhetDTO.personident))
+                    oppfolgingsenhet?.enhetId?.isNavUtland() shouldBeEqualTo true
+
+                    val updatePersonDTO = behandlendeEnhetDTO.copy(isNavUtland = false, oppfolgingsenhet = null)
+                    val responsePost = client.post(personUrl) {
+                        bearerAuth(validToken)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(updatePersonDTO)
+                    }
+                    responsePost.status shouldBeEqualTo HttpStatusCode.OK
+
+                    val oppfolgingsenhetUpdate = repository.getOppfolgingsenhetByPersonident(PersonIdentNumber(updatePersonDTO.personident))
+                    oppfolgingsenhetUpdate?.enhetId shouldBe null
+
+                    val kafkaRecordSlot = mutableListOf<ProducerRecord<String, KBehandlendeEnhetUpdate>>()
+                    verify(exactly = 2) { kafkaProducerMock.send(capture(kafkaRecordSlot)) }
+                    kafkaRecordSlot[0].value().personident shouldBeEqualTo oppfolgingsenhetUpdate?.personident?.value
+                    kafkaRecordSlot[1].value().updatedAt shouldBeEqualTo oppfolgingsenhetUpdate?.createdAt
+                    kafkaRecordSlot[0].value().updatedAt shouldBeLessThan kafkaRecordSlot[1].value().updatedAt
+                }
+            }
+        }
+
+        describe("Unhappy path") {
+            it("should return status Unauthorized if no token is supplied") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val response = client.post(personUrl) {
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetDTO)
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.Unauthorized
+                }
+            }
+
+            it("should return status Forbidden if NAVIdent is denied access") {
+                testApplication {
+                    val validTokenNoAccess = generateJWT(
+                        audience = externalMockEnvironment.environment.azureAppClientId,
+                        issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                        navIdent = VEILEDER_IDENT_NO_ACCESS,
+                    )
+                    val client = setupApiAndClient()
+                    val response = client.post(personUrl) {
+                        bearerAuth(validTokenNoAccess)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetDTO)
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.Forbidden
+                }
+            }
+            it("should return status BadRequest if kode 6/7") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val response = client.post(personUrl) {
+                        bearerAuth(validToken)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetDTO.copy(personident = ARBEIDSTAKER_ADRESSEBESKYTTET.value))
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.BadRequest
+                }
+            }
+            it("should return status BadRequest if egen ansatt") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val response = client.post(personUrl) {
+                        bearerAuth(validToken)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        setBody(behandlendeEnhetDTO.copy(personident = ARBEIDSTAKER_EGENANSATT.value))
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.BadRequest
+                }
+            }
+        }
+    }
     describe("Get mulige oppfolgingsenheter") {
         describe("Happy path") {
             it("Get mulige oppfolgingsenheter") {
                 testApplication {
                     repository.createOppfolgingsenhet(
-                        personIdent = ARBEIDSTAKER_PERSONIDENT,
+                        personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
                         enhetId = EnhetId(UNDERORDNET_NR),
-                        veilederident = VEILEDER_IDENT,
+                        veilederident = UserConstants.VEILEDER_IDENT,
                     )
                     val client = setupApiAndClient()
                     val response = client.get(tilordningsenheterUrl) {
@@ -186,7 +392,7 @@ class BehandlendeEnhetApiSpek : Spek({
         }
     }
 
-    describe("Update oppfolgingsenhet - bulk endpoint") {
+    describe("Update multiple oppfolgingsenheter") {
         it("Updates multiple oppfolgingsenheter successfully") {
             val requestDTO = generateTildelOppfolgingsenhetRequestDTO(
                 personidenter = listOf(
@@ -439,46 +645,6 @@ class BehandlendeEnhetApiSpek : Spek({
                 responseDTO.errors.find { it.personident == ARBEIDSTAKER_GEOGRAFISK_TILKNYTNING_NOT_FOUND.value } shouldNotBe null
 
                 verify(exactly = 1) { kafkaProducerMock.send(any()) }
-            }
-        }
-
-        describe("Unhappy path") {
-            val requestDTO = generateTildelOppfolgingsenhetRequestDTO(
-                personidenter = listOf(ARBEIDSTAKER_PERSONIDENT.value),
-                oppfolgingsenhet = ENHET_ID,
-            )
-            it("should return status Unauthorized if no token is supplied") {
-                testApplication {
-                    val client = setupApiAndClient()
-                    val response = client.post(oppfolgingsenhetTildelingerUrl) {
-                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        setBody(requestDTO)
-                    }
-                    response.status shouldBeEqualTo HttpStatusCode.Unauthorized
-                }
-            }
-
-            it("should return status BadRequest if kode 6/7") {
-                testApplication {
-                    val client = setupApiAndClient()
-                    val response = client.post(oppfolgingsenhetTildelingerUrl) {
-                        bearerAuth(validToken)
-                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        setBody(requestDTO.copy(personidenter = listOf(ARBEIDSTAKER_ADRESSEBESKYTTET.value)))
-                    }
-                    response.status shouldBeEqualTo HttpStatusCode.Forbidden
-                }
-            }
-            it("should return status BadRequest if egen ansatt") {
-                testApplication {
-                    val client = setupApiAndClient()
-                    val response = client.post(oppfolgingsenhetTildelingerUrl) {
-                        bearerAuth(validToken)
-                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                        setBody(requestDTO.copy(personidenter = listOf(ARBEIDSTAKER_EGENANSATT.value)))
-                    }
-                    response.status shouldBeEqualTo HttpStatusCode.Forbidden
-                }
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemApiSpek.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetProducer
 import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.infrastructure.database.repository.EnhetRepository
 import no.nav.syfo.testhelper.*
+import no.nav.syfo.testhelper.mock.norg2Response
 import no.nav.syfo.util.*
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
@@ -68,6 +69,8 @@ class BehandlendeEnhetSystemApiSpek : Spek({
                             response.status shouldBeEqualTo HttpStatusCode.OK
                             val behandlendeEnhet = response.body<BehandlendeEnhetResponseDTO>()
 
+                            behandlendeEnhet.enhetId shouldBeEqualTo norg2Response.first().enhetNr
+                            behandlendeEnhet.navn shouldBeEqualTo norg2Response.first().navn
                             behandlendeEnhet.geografiskEnhet.enhetId shouldBeEqualTo "0101"
                             behandlendeEnhet.geografiskEnhet.navn shouldBeEqualTo "Enhet"
                             behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo "0101"

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/GenerateOppfolgingsenhet.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/GenerateOppfolgingsenhet.kt
@@ -1,7 +1,19 @@
 package no.nav.syfo.testhelper.generator
 
+import no.nav.syfo.behandlendeenhet.api.BehandlendeEnhetDTO
 import no.nav.syfo.behandlendeenhet.api.TildelOppfolgingsenhetRequestDTO
+import no.nav.syfo.domain.EnhetId.Companion.ENHETNR_NAV_UTLAND
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
+
+fun generateBehandlendeEnhetDTO(
+    personident: String = ARBEIDSTAKER_PERSONIDENT.value,
+    isNavUtland: Boolean = true,
+    oppfolgingsenhet: String? = null,
+) = BehandlendeEnhetDTO(
+    personident = personident,
+    isNavUtland = isNavUtland,
+    oppfolgingsenhet = if (isNavUtland) ENHETNR_NAV_UTLAND else oppfolgingsenhet,
+)
 
 fun generateTildelOppfolgingsenhetRequestDTO(
     personidenter: List<String> = listOf(ARBEIDSTAKER_PERSONIDENT.value),

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
@@ -9,7 +9,6 @@ import no.nav.syfo.infrastructure.client.veiledertilgang.TilgangDTO
 import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.ACCESS_TO_BRUKERE_PATH
 import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.ACCESS_TO_SYFO_PATH
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
-import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_EGENANSATT
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_NO_ACCESS
 
 val tilgangFalse = TilgangDTO(
@@ -36,7 +35,7 @@ suspend fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequest
         }
         requestUrl.endsWith(ACCESS_TO_BRUKERE_PATH) -> {
             val personidenter = request.receiveBody<List<String>>()
-            val personerWhereTilgangOk = personidenter.filter { !(it == ARBEIDSTAKER_ADRESSEBESKYTTET.value || it == ARBEIDSTAKER_EGENANSATT.value) }
+            val personerWhereTilgangOk = personidenter.filter { it != ARBEIDSTAKER_ADRESSEBESKYTTET.value }
             respond(personerWhereTilgangOk)
         }
         else -> error("Unhandled path $requestUrl")


### PR DESCRIPTION
Reverts navikt/syfobehandlendeenhet#190

Ved å fjerne feltene i `BehandlendeEnhetResponseDTO` så crasher det i syfooversiktsrv, så jeg skal bare lage en PR der først. Reverter siden det er feriedag og er ikke sikkert jeg får godkjent de andre endringene med det første.