### PR TITLE
Revert "Revert "IS-3263: Remove unused post-endpoint for tildeling oppfolgingsenhet for one person""

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetDTO.kt
@@ -1,11 +1,5 @@
 package no.nav.syfo.behandlendeenhet.api
 
-data class BehandlendeEnhetDTO(
-    val personident: String,
-    val isNavUtland: Boolean,
-    val oppfolgingsenhet: String? = null,
-)
-
 data class TildelOppfolgingsenhetRequestDTO(
     val personidenter: List<String>,
     val oppfolgingsenhet: String,

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemAPI.kt
@@ -38,7 +38,7 @@ fun Route.registrerSystemApi(
                 personIdentNumber = personIdentNumber,
                 veilederToken = null,
             )
-                .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) ?: HttpStatusCode.NoContent }
+                .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) }
                 .run { call.respond(this) }
         }
         post(systemdBehandlendeEnhetApiV2PersonIdentPath) {

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Oppfolgingsenhet.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Oppfolgingsenhet.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.behandlendeenhet.domain
 
-import no.nav.syfo.behandlendeenhet.api.BehandlendeEnhetDTO
 import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.domain.PersonIdentNumber
 import java.time.OffsetDateTime
@@ -12,10 +11,4 @@ data class Oppfolgingsenhet(
     val enhetId: EnhetId?,
     val veilederident: String,
     val createdAt: OffsetDateTime,
-)
-
-fun Oppfolgingsenhet.toBehandlendeEnhetDTO() = BehandlendeEnhetDTO(
-    personident = this.personident.value,
-    isNavUtland = this.enhetId?.isNavUtland() ?: false,
-    oppfolgingsenhet = this.enhetId?.value,
 )

--- a/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/system/BehandlendeEnhetSystemApiSpek.kt
@@ -14,7 +14,6 @@ import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetProducer
 import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.infrastructure.database.repository.EnhetRepository
 import no.nav.syfo.testhelper.*
-import no.nav.syfo.testhelper.mock.norg2Response
 import no.nav.syfo.util.*
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
@@ -69,8 +68,6 @@ class BehandlendeEnhetSystemApiSpek : Spek({
                             response.status shouldBeEqualTo HttpStatusCode.OK
                             val behandlendeEnhet = response.body<BehandlendeEnhetResponseDTO>()
 
-                            behandlendeEnhet.enhetId shouldBeEqualTo norg2Response.first().enhetNr
-                            behandlendeEnhet.navn shouldBeEqualTo norg2Response.first().navn
                             behandlendeEnhet.geografiskEnhet.enhetId shouldBeEqualTo "0101"
                             behandlendeEnhet.geografiskEnhet.navn shouldBeEqualTo "Enhet"
                             behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo "0101"

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/GenerateOppfolgingsenhet.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/GenerateOppfolgingsenhet.kt
@@ -1,19 +1,7 @@
 package no.nav.syfo.testhelper.generator
 
-import no.nav.syfo.behandlendeenhet.api.BehandlendeEnhetDTO
 import no.nav.syfo.behandlendeenhet.api.TildelOppfolgingsenhetRequestDTO
-import no.nav.syfo.domain.EnhetId.Companion.ENHETNR_NAV_UTLAND
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
-
-fun generateBehandlendeEnhetDTO(
-    personident: String = ARBEIDSTAKER_PERSONIDENT.value,
-    isNavUtland: Boolean = true,
-    oppfolgingsenhet: String? = null,
-) = BehandlendeEnhetDTO(
-    personident = personident,
-    isNavUtland = isNavUtland,
-    oppfolgingsenhet = if (isNavUtland) ENHETNR_NAV_UTLAND else oppfolgingsenhet,
-)
 
 fun generateTildelOppfolgingsenhetRequestDTO(
     personidenter: List<String> = listOf(ARBEIDSTAKER_PERSONIDENT.value),

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.infrastructure.client.veiledertilgang.TilgangDTO
 import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.ACCESS_TO_BRUKERE_PATH
 import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.ACCESS_TO_SYFO_PATH
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_EGENANSATT
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_NO_ACCESS
 
 val tilgangFalse = TilgangDTO(
@@ -35,7 +36,7 @@ suspend fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequest
         }
         requestUrl.endsWith(ACCESS_TO_BRUKERE_PATH) -> {
             val personidenter = request.receiveBody<List<String>>()
-            val personerWhereTilgangOk = personidenter.filter { it != ARBEIDSTAKER_ADRESSEBESKYTTET.value }
+            val personerWhereTilgangOk = personidenter.filter { !(it == ARBEIDSTAKER_ADRESSEBESKYTTET.value || it == ARBEIDSTAKER_EGENANSATT.value) }
             respond(personerWhereTilgangOk)
         }
         else -> error("Unhandled path $requestUrl")


### PR DESCRIPTION
Reverts navikt/syfobehandlendeenhet#191

Reverter reverten som kan merges når endringene i syfooversiktsrv er på plass.
EDIT: GET-systemapi brukes flere steder og endringene i DTOen er breaking.