### PR TITLE
IS-3211: Remove-logging

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -65,7 +65,6 @@ class EnhetService(
                     behandlendeEnhetProducer.sendBehandlendeEnhetUpdate(it, it.createdAt)
                 }
             } else {
-                log.warn("Attempt to update oppfolgingsenhet for person with enhetId=$enhetId, geografiskEnhet=$geografiskEnhet, currentOppfolgingsenhet=$currentOppfolgingsenhet failed, returning null")
                 null
             }
         } else {


### PR DESCRIPTION
Har sett på logginnslagene her: https://logs.adeo.no/s/nav-logs-legacy/app/r/s/XsGzf
Dette kommer fra cronjob i syfooversiktsrv som "rydder opp" (ReaperCronjob) de personene i oversikten som er mer enn 2 mnd uten nytt oppfølgingstilfelle og enhet skal dermed nullstilles. Det ble logget som om det var en "feil", men det er da altså en "by-design" flyt for systemet at man skal havne inn i `else`-en her og returnere null.