### PR TITLE
Reapply "IS-3171: Inkluder tidspunkt og veilederident for oppfolgingsenhet (#193)" (#196)

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/Enhet.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/Enhet.kt
@@ -1,8 +1,0 @@
-package no.nav.syfo.behandlendeenhet
-
-import java.io.Serializable
-
-data class Enhet(
-    val enhetId: String,
-    val navn: String,
-) : Serializable

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -14,10 +14,12 @@ import no.nav.syfo.infrastructure.client.pdl.domain.gradering
 import no.nav.syfo.infrastructure.client.pdl.domain.toArbeidsfordelingCriteriaDiskresjonskode
 import no.nav.syfo.infrastructure.client.skjermedepersonerpip.SkjermedePersonerPipClient
 import no.nav.syfo.domain.PersonIdentNumber
-import no.nav.syfo.domain.BehandlendeEnhet
+import no.nav.syfo.behandlendeenhet.domain.BehandlendeEnhet
+import no.nav.syfo.behandlendeenhet.domain.Enhet
 import no.nav.syfo.infrastructure.client.norg.domain.NorgEnhet
 import no.nav.syfo.infrastructure.client.pdl.domain.isKode6
 import no.nav.syfo.infrastructure.client.pdl.domain.isKode7
+import no.nav.syfo.infrastructure.database.repository.toOppfolgingsenhet
 import org.slf4j.LoggerFactory
 import org.slf4j.Logger
 
@@ -35,14 +37,12 @@ class EnhetService(
         personIdentNumber: PersonIdentNumber,
         veilederToken: Token? = null,
     ): BehandlendeEnhet {
-        val oppfolgingsenhet = getOppfolgingsenhet(personIdentNumber)?.enhetId?.let { enhet ->
-            Enhet(
-                enhetId = enhet.value,
-                navn = getEnhetsnavn(enhet),
-            )
-        }
+        val oppfolgingsenhet = getOppfolgingsenhet(personIdentNumber)
         val geografiskEnhet = findGeografiskEnhet(callId, personIdentNumber, veilederToken)
-        return BehandlendeEnhet(geografiskEnhet, oppfolgingsenhet)
+        return BehandlendeEnhet(
+            geografiskEnhet = geografiskEnhet,
+            oppfolgingsenhet = oppfolgingsenhet,
+        )
     }
 
     suspend fun updateOppfolgingsenhet(
@@ -57,11 +57,14 @@ class EnhetService(
                 personIdentNumber = personIdent,
                 veilederToken = veilederToken,
             )
-            val newBehandlendeEnhet = if (enhetId?.value != geografiskEnhet.enhetId) enhetId else null
+            val newBehandlendeEnhet = if (enhetId != geografiskEnhet.enhetId) enhetId else null
             val currentOppfolgingsenhet = getOppfolgingsenhet(personIdent)
             val navIdent = veilederToken?.getNAVIdent() ?: SYSTEM_USER_IDENT
             if (newBehandlendeEnhet != null || currentOppfolgingsenhet != null) {
-                repository.createOppfolgingsenhet(personIdent, newBehandlendeEnhet, navIdent).also {
+                val pOppfolgingsenhet = repository.createOppfolgingsenhet(personIdent, newBehandlendeEnhet, navIdent)
+                pOppfolgingsenhet.toOppfolgingsenhet(
+                    enhetNavn = getEnhetsnavn(newBehandlendeEnhet),
+                ).also {
                     behandlendeEnhetProducer.sendBehandlendeEnhetUpdate(it, it.createdAt)
                 }
             } else {
@@ -131,7 +134,7 @@ class EnhetService(
                     .excludeCurrentEnhet(currentEnhetId)
                     .map {
                         Enhet(
-                            enhetId = it.enhetNr,
+                            enhetId = EnhetId(it.enhetNr),
                             navn = it.navn,
                         )
                     }
@@ -145,10 +148,10 @@ class EnhetService(
     ) = this.filter { it.enhetNr != currentEnhetId.value }
 
     private fun addNavUtlandAndSortAccordingToUsage(enhetList: List<Enhet>, veilederident: String) =
-        mutableListOf(Enhet(ENHETNR_NAV_UTLAND, ENHETNAVN_NAV_UTLAND)).apply {
+        mutableListOf(Enhet(EnhetId(ENHETNR_NAV_UTLAND), ENHETNAVN_NAV_UTLAND)).apply {
             addAll(
                 repository.getEnhetUsageForVeileder(veilederident).mapNotNull { enhetId ->
-                    enhetList.find { it.enhetId == enhetId.value }
+                    enhetList.find { it.enhetId == enhetId }
                 }
             )
             addAll(enhetList)
@@ -172,24 +175,30 @@ class EnhetService(
         return !isEgenAnsatt && (graderingList == null || graderingList.none { it.isKode6() || it.isKode7() })
     }
 
-    private fun getOppfolgingsenhet(personIdent: PersonIdentNumber): Oppfolgingsenhet? {
-        return repository.getOppfolgingsenhetByPersonident(personIdent)
+    private suspend fun getOppfolgingsenhet(personIdent: PersonIdentNumber): Oppfolgingsenhet? {
+        return repository.getOppfolgingsenhetByPersonident(personIdent)?.let {
+            it.toOppfolgingsenhet(
+                enhetNavn = getEnhetsnavn(it.oppfolgingsenhet?.let { EnhetId(it) })
+            )
+        }
     }
 
-    private suspend fun getEnhetsnavn(oppfolgingsenhet: EnhetId) =
-        if (oppfolgingsenhet.isNavUtland()) {
-            ENHETNAVN_NAV_UTLAND
-        } else {
-            norgClient.getEnhetsnavn(oppfolgingsenhet.value) ?: ENHETSNAVN_MANGLER
-        }
+    private suspend fun getEnhetsnavn(oppfolgingsenhet: EnhetId?) =
+        oppfolgingsenhet?.let {
+            if (it.isNavUtland()) {
+                ENHETNAVN_NAV_UTLAND
+            } else {
+                norgClient.getEnhetsnavn(it.value)
+            }
+        } ?: ENHETSNAVN_MANGLER
 
     private fun isEnhetUtvandret(enhet: Enhet?): Boolean {
-        return enhet?.enhetId == GEOGRAFISK_TILKNYTNING_UTVANDRET
+        return enhet?.enhetId?.value == GEOGRAFISK_TILKNYTNING_UTVANDRET
     }
 
     private fun getEnhetNAVUtland(): Enhet {
         return Enhet(
-            enhetId = ENHETNR_NAV_UTLAND,
+            enhetId = EnhetId(ENHETNR_NAV_UTLAND),
             navn = ENHETNAVN_NAV_UTLAND,
         )
     }

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/IEnhetRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/IEnhetRepository.kt
@@ -1,8 +1,8 @@
 package no.nav.syfo.behandlendeenhet
 
-import no.nav.syfo.behandlendeenhet.domain.Oppfolgingsenhet
 import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.infrastructure.database.repository.POppfolgingsenhet
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -11,9 +11,9 @@ interface IEnhetRepository {
         personIdent: PersonIdentNumber,
         enhetId: EnhetId?,
         veilederident: String,
-    ): Oppfolgingsenhet
+    ): POppfolgingsenhet
 
-    fun getOppfolgingsenhetByPersonident(personIdent: PersonIdentNumber): Oppfolgingsenhet?
+    fun getOppfolgingsenhetByPersonident(personIdent: PersonIdentNumber): POppfolgingsenhet?
 
     fun getEnhetUsageForVeileder(veilederident: String): List<EnhetId>
 

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/BehandlendeEnhetResponseDTO.kt
@@ -1,26 +1,53 @@
 package no.nav.syfo.behandlendeenhet.api
 
-import no.nav.syfo.behandlendeenhet.Enhet
-import no.nav.syfo.domain.BehandlendeEnhet
+import no.nav.syfo.behandlendeenhet.domain.Enhet
+import no.nav.syfo.behandlendeenhet.domain.BehandlendeEnhet
+import java.time.OffsetDateTime
 
 data class BehandlendeEnhetResponseDTO(
     @Deprecated("Erstattet av geografisk enhet og oppfolgingsenhet")
     val enhetId: String,
     @Deprecated("Erstattet av geografisk enhet og oppfolgingsenhet")
     val navn: String,
-    val geografiskEnhet: Enhet,
-    val oppfolgingsenhet: Enhet,
+
+    val geografiskEnhet: EnhetDTO,
+    val oppfolgingsenhet: EnhetDTO, // TODO: remove when not used anymore
+    val oppfolgingsenhetDTO: OppfolgingsenhetDTO?,
 ) {
     companion object {
         fun fromBehandlendeEnhet(behandlendeEnhet: BehandlendeEnhet): BehandlendeEnhetResponseDTO {
-            val oppfolgingsenhet = behandlendeEnhet.oppfolgingsenhet ?: behandlendeEnhet.geografiskEnhet
-
+            val oppfolgingsenhet = behandlendeEnhet.oppfolgingsenhet?.enhet ?: behandlendeEnhet.geografiskEnhet
             return BehandlendeEnhetResponseDTO(
-                enhetId = oppfolgingsenhet.enhetId,
+                enhetId = oppfolgingsenhet.enhetId.value,
                 navn = oppfolgingsenhet.navn,
-                geografiskEnhet = behandlendeEnhet.geografiskEnhet,
-                oppfolgingsenhet = oppfolgingsenhet,
+                geografiskEnhet = behandlendeEnhet.geografiskEnhet.toEnhetDTO(),
+                oppfolgingsenhet = oppfolgingsenhet.toEnhetDTO(),
+                oppfolgingsenhetDTO = behandlendeEnhet.oppfolgingsenhet?.enhet?.let {
+                    OppfolgingsenhetDTO(
+                        enhet = behandlendeEnhet.oppfolgingsenhet.enhet.toEnhetDTO(),
+                        createdAt = behandlendeEnhet.oppfolgingsenhet.createdAt,
+                        veilederident = behandlendeEnhet.oppfolgingsenhet.veilederident,
+                    )
+                }
             )
         }
     }
+}
+
+data class OppfolgingsenhetDTO(
+    val enhet: EnhetDTO,
+    val createdAt: OffsetDateTime,
+    val veilederident: String,
+)
+
+data class EnhetDTO(
+    val enhetId: String,
+    val navn: String,
+)
+
+fun Enhet.toEnhetDTO(): EnhetDTO {
+    return EnhetDTO(
+        enhetId = this.enhetId.value,
+        navn = this.navn,
+    )
 }

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
@@ -68,7 +68,7 @@ fun Route.registrerPersonApi(
 
             val tilordningsenheter = enhetService.getMuligeOppfolgingsenheter(callId, EnhetId(enhetId), veilederident)
 
-            call.respond(tilordningsenheter)
+            call.respond(tilordningsenheter.map { it.toEnhetDTO() })
         }
 
         post("/oppfolgingsenhet-tildelinger") {
@@ -116,7 +116,7 @@ fun Route.registrerPersonApi(
                     val oppfolgingsenhet = it.getOrThrow()
                     TildelOppfolgingsenhetDTO(
                         personident = oppfolgingsenhet.personident.value,
-                        oppfolgingsenhet = oppfolgingsenhet.enhetId?.value,
+                        oppfolgingsenhet = oppfolgingsenhet.enhet?.enhetId?.value,
                     )
                 }
             val unsuccessfulTildelinger = errorneousPersonidenter

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/BehandlendeEnhet.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/BehandlendeEnhet.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.behandlendeenhet.domain
+
+/**
+ * Representerer behandlende enhet for en sykmeldt
+ *
+ * @property geografiskEnhet Den geografiske enheten til den sykmeldte. Grunnregelen er at den sykmeldte får oppfølging her.
+ * @property oppfolgingsenhet Om oppfølgingen av en eller annen grunn ikke skal skje ved den geografiske enheten er det oppgitt en oppfølgingsenhet.
+ */
+data class BehandlendeEnhet(
+    val geografiskEnhet: Enhet,
+    val oppfolgingsenhet: Oppfolgingsenhet?,
+)

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Enhet.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Enhet.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.behandlendeenhet.domain
+
+import no.nav.syfo.domain.EnhetId
+import java.io.Serializable
+
+data class Enhet(
+    val enhetId: EnhetId,
+    val navn: String,
+) : Serializable

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Oppfolgingsenhet.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/domain/Oppfolgingsenhet.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.behandlendeenhet.domain
 
-import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.domain.PersonIdentNumber
 import java.time.OffsetDateTime
 import java.util.*
@@ -8,7 +7,7 @@ import java.util.*
 data class Oppfolgingsenhet(
     val uuid: UUID,
     val personident: PersonIdentNumber,
-    val enhetId: EnhetId?,
+    val enhet: Enhet?,
     val veilederident: String,
     val createdAt: OffsetDateTime,
 )

--- a/src/main/kotlin/no/nav/syfo/domain/BehandlendeEnhet.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/BehandlendeEnhet.kt
@@ -1,8 +1,0 @@
-package no.nav.syfo.domain
-
-import no.nav.syfo.behandlendeenhet.Enhet
-
-data class BehandlendeEnhet(
-    val geografiskEnhet: Enhet,
-    val oppfolgingsenhet: Enhet?,
-)

--- a/src/main/kotlin/no/nav/syfo/identhendelse/IdenthendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/IdenthendelseService.kt
@@ -22,7 +22,9 @@ class IdenthendelseService(
             if (activeIdent != null) {
                 val inactiveIdenter = identhendelse.getInactivePersonidenter()
                 val oldPersonIdentList = inactiveIdenter.mapNotNull { personident ->
-                    repository.getOppfolgingsenhetByPersonident(personident)?.personident
+                    repository.getOppfolgingsenhetByPersonident(personident)?.personident?.let {
+                        PersonIdentNumber(it)
+                    }
                 }
 
                 if (oldPersonIdentList.isNotEmpty()) {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/norg/NorgClient.kt
@@ -6,7 +6,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import no.nav.syfo.infrastructure.cache.ValkeyStore
-import no.nav.syfo.behandlendeenhet.Enhet
+import no.nav.syfo.behandlendeenhet.domain.Enhet
 import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.infrastructure.client.norg.domain.*
 import no.nav.syfo.infrastructure.client.pdl.GeografiskTilknytning
@@ -70,8 +70,8 @@ class NorgClient(
         ).filter { it.status == Enhetsstatus.AKTIV.formattedName }
             .map {
                 Enhet(
-                    it.enhetNr,
-                    it.navn
+                    enhetId = EnhetId(it.enhetNr),
+                    navn = it.navn
                 )
             }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/EnhetRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/EnhetRepository.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.infrastructure.database.repository
 
 import no.nav.syfo.behandlendeenhet.IEnhetRepository
-import no.nav.syfo.behandlendeenhet.domain.Oppfolgingsenhet
 import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.domain.EnhetId.Companion.ENHETNR_NAV_UTLAND
 import no.nav.syfo.domain.PersonIdentNumber
@@ -17,7 +16,7 @@ class EnhetRepository(private val database: DatabaseInterface) : IEnhetRepositor
         personIdent: PersonIdentNumber,
         enhetId: EnhetId?,
         veilederident: String,
-    ): Oppfolgingsenhet =
+    ): POppfolgingsenhet =
         database.connection.use { connection ->
             val now = OffsetDateTime.now()
             connection.prepareStatement(createOppfolgingsenhet).use {
@@ -31,7 +30,7 @@ class EnhetRepository(private val database: DatabaseInterface) : IEnhetRepositor
             }.also {
                 connection.commit()
             }
-        }.first().toOppfolgingsenhet()
+        }.first()
 
     override fun getEnhetUsageForVeileder(veilederident: String): List<EnhetId> =
         database.connection.use { connection ->
@@ -42,14 +41,14 @@ class EnhetRepository(private val database: DatabaseInterface) : IEnhetRepositor
                 }
         }
 
-    override fun getOppfolgingsenhetByPersonident(personIdent: PersonIdentNumber): Oppfolgingsenhet? =
+    override fun getOppfolgingsenhetByPersonident(personIdent: PersonIdentNumber): POppfolgingsenhet? =
         database.connection.use { connection ->
             connection.prepareStatement(queryOppfolgingsenhetByPersonident)
                 .use {
                     it.setString(1, personIdent.value)
                     it.executeQuery().toList { toPOppfolgingsenhet() }
                 }
-        }.firstOrNull()?.toOppfolgingsenhet()
+        }.firstOrNull()
 
     override fun getActiveOppfolgingsenheter(): List<Pair<UUID, PersonIdentNumber>> =
         database.connection.use { connection ->

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/POppfolgingsenhet.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/POppfolgingsenhet.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.infrastructure.database.repository
 
+import no.nav.syfo.behandlendeenhet.domain.Enhet
 import no.nav.syfo.behandlendeenhet.domain.Oppfolgingsenhet
 import no.nav.syfo.domain.EnhetId
 import no.nav.syfo.domain.PersonIdentNumber
@@ -15,10 +16,15 @@ data class POppfolgingsenhet(
     val createdAt: OffsetDateTime,
 )
 
-fun POppfolgingsenhet.toOppfolgingsenhet() = Oppfolgingsenhet(
+fun POppfolgingsenhet.toOppfolgingsenhet(enhetNavn: String) = Oppfolgingsenhet(
     uuid = this.uuid,
     personident = PersonIdentNumber(this.personident),
-    enhetId = this.oppfolgingsenhet?.let { EnhetId(it) },
+    enhet = this.oppfolgingsenhet?.let {
+        Enhet(
+            enhetId = EnhetId(it),
+            navn = enhetNavn,
+        )
+    },
     veilederident = veilederident,
     createdAt = this.createdAt,
 )

--- a/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiSpek.kt
@@ -10,8 +10,8 @@ import io.ktor.server.testing.*
 import io.mockk.clearMocks
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.syfo.behandlendeenhet.Enhet
 import no.nav.syfo.behandlendeenhet.api.BehandlendeEnhetResponseDTO
+import no.nav.syfo.behandlendeenhet.api.EnhetDTO
 import no.nav.syfo.behandlendeenhet.api.TildelOppfolgingsenhetResponseDTO
 import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetProducer
 import no.nav.syfo.behandlendeenhet.kafka.KBehandlendeEnhetUpdate
@@ -36,6 +36,7 @@ import no.nav.syfo.testhelper.mock.GEOGRAFISK_ENHET_NR_2
 import no.nav.syfo.testhelper.mock.UNDERORDNET_NR
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.configure
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBe
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -98,6 +99,34 @@ class BehandlendeEnhetApiSpek : Spek({
                     behandlendeEnhet.geografiskEnhet.navn shouldBeEqualTo "Enhet"
                     behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo "0101"
                     behandlendeEnhet.oppfolgingsenhet.navn shouldBeEqualTo "Enhet"
+                    behandlendeEnhet.oppfolgingsenhetDTO?.enhet shouldBe null
+                    behandlendeEnhet.oppfolgingsenhetDTO?.createdAt shouldBe null
+                    behandlendeEnhet.oppfolgingsenhetDTO?.veilederident shouldBe null
+                }
+            }
+            it("Get BehandlendeEnhet when oppfolgingsenhet has been set") {
+                testApplication {
+                    repository.createOppfolgingsenhet(
+                        personIdent = ARBEIDSTAKER_PERSONIDENT,
+                        enhetId = EnhetId(UNDERORDNET_NR),
+                        veilederident = VEILEDER_IDENT,
+                    )
+                    val client = setupApiAndClient()
+                    val response = client.get(behandlendeEnhetUrl) {
+                        bearerAuth(validToken)
+                        header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
+                    }
+                    response.status shouldBeEqualTo HttpStatusCode.OK
+                    val behandlendeEnhet = response.body<BehandlendeEnhetResponseDTO>()
+
+                    behandlendeEnhet.geografiskEnhet.enhetId shouldBeEqualTo "0101"
+                    behandlendeEnhet.geografiskEnhet.navn shouldBeEqualTo "Enhet"
+                    behandlendeEnhet.oppfolgingsenhet.enhetId shouldBeEqualTo UNDERORDNET_NR
+                    behandlendeEnhet.oppfolgingsenhet.navn shouldBeEqualTo "Enhet"
+                    behandlendeEnhet.oppfolgingsenhetDTO?.enhet?.enhetId shouldBeEqualTo UNDERORDNET_NR
+                    behandlendeEnhet.oppfolgingsenhetDTO?.enhet?.navn shouldBeEqualTo "Enhet"
+                    behandlendeEnhet.oppfolgingsenhetDTO?.createdAt shouldNotBe null
+                    behandlendeEnhet.oppfolgingsenhetDTO?.veilederident shouldBeEqualTo VEILEDER_IDENT
                 }
             }
 
@@ -174,7 +203,7 @@ class BehandlendeEnhetApiSpek : Spek({
                         bearerAuth(validToken)
                     }
                     response.status shouldBeEqualTo HttpStatusCode.OK
-                    val behandlendeEnhetList = response.body<List<Enhet>>()
+                    val behandlendeEnhetList = response.body<List<EnhetDTO>>()
 
                     behandlendeEnhetList.size shouldBeEqualTo 3
                     behandlendeEnhetList[0].enhetId shouldBeEqualTo EnhetId.ENHETNR_NAV_UTLAND
@@ -365,8 +394,8 @@ class BehandlendeEnhetApiSpek : Spek({
                 val oppfolgingsenhetPerson2 = repository.getOppfolgingsenhetByPersonident(ARBEIDSTAKER_PERSONIDENT_2)
                 val oppfolgingsenhetPerson3 =
                     repository.getOppfolgingsenhetByPersonident(ARBEIDSTAKER_GEOGRAFISK_TILKNYTNING_NOT_FOUND)
-                oppfolgingsenhetPerson1?.enhetId?.value shouldBeEqualTo ENHET_ID
-                oppfolgingsenhetPerson2?.enhetId?.value shouldBeEqualTo ENHET_ID
+                oppfolgingsenhetPerson1?.oppfolgingsenhet shouldBeEqualTo ENHET_ID
+                oppfolgingsenhetPerson2?.oppfolgingsenhet shouldBeEqualTo ENHET_ID
                 oppfolgingsenhetPerson3 shouldBeEqualTo null
 
                 responseDTO.tildelinger.size shouldBeEqualTo 2
@@ -428,7 +457,7 @@ class BehandlendeEnhetApiSpek : Spek({
                 val oppfolgingsenhetPerson1 = repository.getOppfolgingsenhetByPersonident(ARBEIDSTAKER_PERSONIDENT)
                 val oppfolgingsenhetPerson2 = repository.getOppfolgingsenhetByPersonident(ARBEIDSTAKER_ADRESSEBESKYTTET)
                 val oppfolgingsenhetPerson3 = repository.getOppfolgingsenhetByPersonident(ARBEIDSTAKER_GEOGRAFISK_TILKNYTNING_NOT_FOUND)
-                oppfolgingsenhetPerson1?.enhetId?.value shouldBeEqualTo ENHET_ID
+                oppfolgingsenhetPerson1?.oppfolgingsenhet shouldBeEqualTo ENHET_ID
                 oppfolgingsenhetPerson2 shouldBeEqualTo null
                 oppfolgingsenhetPerson3 shouldBeEqualTo null
 

--- a/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
@@ -74,7 +74,7 @@ object IdenthendelseServiceSpek : Spek({
                 }
 
                 val updated = repository.getOppfolgingsenhetByPersonident(newIdent)
-                updated?.personident?.value shouldBeEqualTo newIdent.value
+                updated?.personident shouldBeEqualTo newIdent.value
 
                 val old = repository.getOppfolgingsenhetByPersonident(oldIdent)
                 old shouldBeEqualTo null
@@ -102,7 +102,7 @@ object IdenthendelseServiceSpek : Spek({
                 }
 
                 val updated = repository.getOppfolgingsenhetByPersonident(newIdent)
-                updated?.personident?.value shouldBeEqualTo newIdent.value
+                updated?.personident shouldBeEqualTo newIdent.value
 
                 val old = repository.getOppfolgingsenhetByPersonident(oldIdent)
                 old shouldBeEqualTo null

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RemoveOppfolgingsenhetCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RemoveOppfolgingsenhetCronjobSpek.kt
@@ -72,7 +72,7 @@ class RemoveOppfolgingsenhetCronjobSpek : Spek({
                         callId = callId,
                         personIdentNumber = UserConstants.ARBEIDSTAKER_PERSONIDENT,
                     )
-                    storedEnhet.oppfolgingsenhet?.enhetId shouldBeEqualTo EnhetId.ENHETNR_NAV_UTLAND
+                    storedEnhet.oppfolgingsenhet?.enhet?.enhetId?.value shouldBeEqualTo EnhetId.ENHETNR_NAV_UTLAND
                 }
             }
             it("Cronjob nuller oppfolgingsenhet på person med skjerming") {
@@ -95,7 +95,7 @@ class RemoveOppfolgingsenhetCronjobSpek : Spek({
                         callId = callId,
                         personIdentNumber = UserConstants.ARBEIDSTAKER_PERSONIDENT,
                     )
-                    storedEnhet.oppfolgingsenhet?.enhetId shouldNotBeEqualTo EnhetId.ENHETNR_NAV_UTLAND
+                    storedEnhet.oppfolgingsenhet?.enhet?.enhetId?.value shouldNotBeEqualTo EnhetId.ENHETNR_NAV_UTLAND
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/ReturnToSenderIfNoVeilederCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/ReturnToSenderIfNoVeilederCronjobSpek.kt
@@ -106,7 +106,7 @@ class ReturnToSenderIfNoVeilederCronjobSpek : Spek({
                         callId = callId,
                         personIdentNumber = UserConstants.ARBEIDSTAKER_PERSONIDENT,
                     )
-                    storedEnhet.oppfolgingsenhet?.enhetId shouldBeEqualTo ENHET_ID
+                    storedEnhet.oppfolgingsenhet?.enhet?.enhetId?.value shouldBeEqualTo ENHET_ID
                     database.getVeilederCheckedOk(oppfolgingsenhet.uuid) shouldNotBe null
                 }
             }
@@ -126,7 +126,7 @@ class ReturnToSenderIfNoVeilederCronjobSpek : Spek({
                         callId = callId,
                         personIdentNumber = UserConstants.ARBEIDSTAKER_PERSONIDENT_2,
                     )
-                    storedEnhet.oppfolgingsenhet?.enhetId shouldBeEqualTo ENHET_ID
+                    storedEnhet.oppfolgingsenhet?.enhet?.enhetId?.value shouldBeEqualTo ENHET_ID
                     database.getVeilederCheckedOk(oppfolgingsenhet.uuid) shouldBe null
                 }
             }
@@ -151,7 +151,7 @@ class ReturnToSenderIfNoVeilederCronjobSpek : Spek({
                         callId = callId,
                         personIdentNumber = UserConstants.ARBEIDSTAKER_PERSONIDENT_2,
                     )
-                    storedEnhet.oppfolgingsenhet?.enhetId shouldBe null
+                    storedEnhet.oppfolgingsenhet?.enhet?.enhetId?.value shouldBe null
                 }
             }
             it("Cronjob nuller ikke ut oppfolgningsenhet for arbeidstaker som ikke har fått veileder etter 7 dager hvis Nav Utland") {
@@ -175,7 +175,7 @@ class ReturnToSenderIfNoVeilederCronjobSpek : Spek({
                         callId = callId,
                         personIdentNumber = UserConstants.ARBEIDSTAKER_PERSONIDENT_2,
                     )
-                    storedEnhet.oppfolgingsenhet?.enhetId shouldBeEqualTo ENHETNR_NAV_UTLAND
+                    storedEnhet.oppfolgingsenhet?.enhet?.enhetId?.value shouldBeEqualTo ENHETNR_NAV_UTLAND
                 }
             }
         }


### PR DESCRIPTION
This reverts commit 55b1f37240d6adc7d0838834ddabb8149bd8400b.

Forsøker på nytt: Denne gangen skal jeg være klar til å flushe valkey-cachen til `syfobehandlendeenhet `i det den blir deployet i prod. Tror det skal gå bedre da.