### PR TITLE
IS-3419: Legge til rette for flytting til og fra ROE

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -16,6 +16,8 @@ import no.nav.syfo.infrastructure.client.skjermedepersonerpip.SkjermedePersonerP
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.behandlendeenhet.domain.BehandlendeEnhet
 import no.nav.syfo.behandlendeenhet.domain.Enhet
+import no.nav.syfo.domain.EnhetId.Companion.VEST_VIKEN_ENHET_ID
+import no.nav.syfo.domain.EnhetId.Companion.VEST_VIKEN_ROE_ID
 import no.nav.syfo.infrastructure.client.pdl.domain.isKode6
 import no.nav.syfo.infrastructure.client.pdl.domain.isKode7
 import no.nav.syfo.infrastructure.database.repository.toOppfolgingsenhet
@@ -32,7 +34,7 @@ class EnhetService(
 ) {
 
     private val roeForFylke = mapOf(
-        "0600" to "0676",
+        VEST_VIKEN_ENHET_ID to VEST_VIKEN_ROE_ID,
     )
 
     suspend fun arbeidstakersBehandlendeEnhet(

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/EnhetService.kt
@@ -18,7 +18,6 @@ import no.nav.syfo.behandlendeenhet.domain.BehandlendeEnhet
 import no.nav.syfo.behandlendeenhet.domain.Enhet
 import no.nav.syfo.domain.EnhetId.Companion.VEST_VIKEN_ENHET_ID
 import no.nav.syfo.domain.EnhetId.Companion.VEST_VIKEN_ROE_ID
-import no.nav.syfo.infrastructure.client.norg.domain.NorgEnhet
 import no.nav.syfo.infrastructure.client.pdl.domain.isKode6
 import no.nav.syfo.infrastructure.client.pdl.domain.isKode7
 import no.nav.syfo.infrastructure.database.repository.toOppfolgingsenhet

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
@@ -87,6 +87,10 @@ fun Route.registrerPersonApi(
             val veilederident = token.getNAVIdent()
 
             // optional header
+            // tjenesten brukes både fra syfomodiaperson og syfooversikt. I det første tilfellet er man i kontekst
+            // av en konkret person og sender med personident som header (slik at man i noen tilfeller får
+            // geografisk enhet som alternativ i responsen). I det andre tilfellet tillates multiple
+            // select, så da gir det ikke mening å sende med en personident.
             val personident = personIdentHeader()?.let { personIdent ->
                 PersonIdentNumber(personIdent)
             }

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetAPI.kt
@@ -86,7 +86,18 @@ fun Route.registrerPersonApi(
                 ?: throw IllegalArgumentException("Could not retrieve BehandlendeEnhet: No enhetId supplied in request")
             val veilederident = token.getNAVIdent()
 
-            val tilordningsenheter = enhetService.getMuligeOppfolgingsenheter(callId, EnhetId(enhetId), veilederident)
+            // optional header
+            val personident = personIdentHeader()?.let { personIdent ->
+                PersonIdentNumber(personIdent)
+            }
+
+            val tilordningsenheter = enhetService.getMuligeOppfolgingsenheter(
+                callId = callId,
+                token = token,
+                currentEnhetId = EnhetId(enhetId),
+                veilederident = veilederident,
+                personident = personident,
+            )
 
             call.respond(tilordningsenheter.map { it.toEnhetDTO() })
         }

--- a/src/main/kotlin/no/nav/syfo/domain/EnhetId.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/EnhetId.kt
@@ -14,5 +14,7 @@ data class EnhetId(val value: String) {
     companion object {
         const val ENHETNR_NAV_UTLAND = "0393"
         const val ENHETNAVN_NAV_UTLAND = "Nav utland"
+        const val VEST_VIKEN_ENHET_ID = "0600"
+        const val VEST_VIKEN_ROE_ID = "0676"
     }
 }

--- a/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiTest.kt
@@ -34,7 +34,7 @@ import no.nav.syfo.testhelper.generateJWT
 import no.nav.syfo.testhelper.generator.generateTildelOppfolgingsenhetRequestDTO
 import no.nav.syfo.testhelper.mock.ENHET_NAVN
 import no.nav.syfo.testhelper.mock.GEOGRAFISK_ENHET_NR
-import no.nav.syfo.testhelper.mock.GEOGRAFISK_ENHET_NR_2
+import no.nav.syfo.testhelper.mock.ROE_NR
 import no.nav.syfo.testhelper.mock.UNDERORDNET_NR
 import no.nav.syfo.testhelper.testApiModule
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
@@ -230,11 +230,9 @@ class BehandlendeEnhetApiTest {
             assertEquals(HttpStatusCode.OK, response.status)
             val behandlendeEnhetList = response.body<List<EnhetDTO>>()
 
-            assertEquals(3, behandlendeEnhetList.size)
+            assertEquals(2, behandlendeEnhetList.size)
             assertEquals(EnhetId.ENHETNR_NAV_UTLAND, behandlendeEnhetList[0].enhetId)
-            // UNDERORDNET_NR (0103) kommer foran GEOGRAFISK_ENHET_NR_2 (0102) fordi veileder har brukt 0103 en gang
-            assertEquals(UNDERORDNET_NR, behandlendeEnhetList[1].enhetId)
-            assertEquals(GEOGRAFISK_ENHET_NR_2, behandlendeEnhetList[2].enhetId)
+            assertEquals(ROE_NR, behandlendeEnhetList[1].enhetId)
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlendeenhet/api/internad/BehandlendeEnhetApiTest.kt
@@ -15,6 +15,7 @@ import no.nav.syfo.behandlendeenhet.api.*
 import no.nav.syfo.behandlendeenhet.kafka.BehandlendeEnhetProducer
 import no.nav.syfo.behandlendeenhet.kafka.KBehandlendeEnhetUpdate
 import no.nav.syfo.domain.EnhetId
+import no.nav.syfo.domain.EnhetId.Companion.VEST_VIKEN_ROE_ID
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.infrastructure.database.repository.EnhetRepository
 import no.nav.syfo.testhelper.ExternalMockEnvironment
@@ -34,7 +35,6 @@ import no.nav.syfo.testhelper.generateJWT
 import no.nav.syfo.testhelper.generator.generateTildelOppfolgingsenhetRequestDTO
 import no.nav.syfo.testhelper.mock.ENHET_NAVN
 import no.nav.syfo.testhelper.mock.GEOGRAFISK_ENHET_NR
-import no.nav.syfo.testhelper.mock.ROE_NR
 import no.nav.syfo.testhelper.mock.UNDERORDNET_NR
 import no.nav.syfo.testhelper.testApiModule
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
@@ -232,7 +232,7 @@ class BehandlendeEnhetApiTest {
 
             assertEquals(2, behandlendeEnhetList.size)
             assertEquals(EnhetId.ENHETNR_NAV_UTLAND, behandlendeEnhetList[0].enhetId)
-            assertEquals(ROE_NR, behandlendeEnhetList[1].enhetId)
+            assertEquals(VEST_VIKEN_ROE_ID, behandlendeEnhetList[1].enhetId)
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
@@ -2,14 +2,14 @@ package no.nav.syfo.testhelper.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
+import no.nav.syfo.domain.EnhetId.Companion.ENHETNR_NAV_UTLAND
+import no.nav.syfo.domain.EnhetId.Companion.VEST_VIKEN_ENHET_ID
 import no.nav.syfo.infrastructure.client.norg.NorgClient.Companion.ENHET_TYPE_LOKAL
 import no.nav.syfo.infrastructure.client.norg.domain.*
 import no.nav.syfo.testhelper.UserConstants.ENHET_ID
 
 const val GEOGRAFISK_ENHET_NR = "0101"
 const val GEOGRAFISK_ENHET_NR_2 = "0102"
-const val OVERORDNET_NR = "0600"
-const val ROE_NR = "0676"
 const val UNDERORDNET_NR = "0103"
 const val ENHET_NAVN = "Enhet"
 const val ENHET_NAVN_2 = "Enhet2"
@@ -38,8 +38,8 @@ fun generateNorgEnhet(): NorgEnhet {
 
 val norg2Response = listOf(generateNorgEnhet())
 val norg2ResponseAnnenKommune = listOf(generateNorgEnhet().copy(enhetNr = ENHET_ID, navn = "Annen kommune"))
-val norg2ResponseNavUtland = listOf(generateNorgEnhet().copy(enhetNr = "0393", navn = "Nav utland"))
-val norg2ResponseOverordnet = listOf(generateNorgEnhet().copy(enhetNr = OVERORDNET_NR, navn = "Overordnet"))
+val norg2ResponseNavUtland = listOf(generateNorgEnhet().copy(enhetNr = ENHETNR_NAV_UTLAND, navn = "Nav utland"))
+val norg2ResponseOverordnet = listOf(generateNorgEnhet().copy(enhetNr = VEST_VIKEN_ENHET_ID, navn = "Overordnet"))
 
 suspend fun MockRequestHandleScope.getNorg2Response(request: HttpRequestData): HttpResponseData {
     val path = request.url.encodedPath
@@ -59,28 +59,28 @@ suspend fun MockRequestHandleScope.getNorg2Response(request: HttpRequestData): H
             listOf(
                 RsOrganisering(
                     orgType = "ENHET",
-                    organiserer = RsSimpleEnhet(OVERORDNET_NR, "Overordnet"),
+                    organiserer = RsSimpleEnhet(VEST_VIKEN_ENHET_ID, "Overordnet"),
                     organisertUnder = RsSimpleEnhet(UNDERORDNET_NR, "Underordnet"),
                     gyldigFra = null,
                     gyldigTil = null,
                 ),
                 RsOrganisering(
                     orgType = "ENHET",
-                    organiserer = RsSimpleEnhet(OVERORDNET_NR, "Overordnet"),
+                    organiserer = RsSimpleEnhet(VEST_VIKEN_ENHET_ID, "Overordnet"),
                     organisertUnder = RsSimpleEnhet(UNDERORDNET_NR, "Underordnet"),
                     gyldigFra = null,
                     gyldigTil = null,
                 ),
                 RsOrganisering(
                     orgType = "ENHET",
-                    organiserer = RsSimpleEnhet(OVERORDNET_NR, "Overordnet"),
+                    organiserer = RsSimpleEnhet(VEST_VIKEN_ENHET_ID, "Overordnet"),
                     organisertUnder = RsSimpleEnhet(GEOGRAFISK_ENHET_NR, ENHET_NAVN),
                     gyldigFra = null,
                     gyldigTil = null,
                 ),
                 RsOrganisering(
                     orgType = "ENHET",
-                    organiserer = RsSimpleEnhet(OVERORDNET_NR, "Overordnet"),
+                    organiserer = RsSimpleEnhet(VEST_VIKEN_ENHET_ID, "Overordnet"),
                     organisertUnder = RsSimpleEnhet(GEOGRAFISK_ENHET_NR_2, ENHET_NAVN_2),
                     gyldigFra = null,
                     gyldigTil = null,

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
@@ -8,7 +8,8 @@ import no.nav.syfo.testhelper.UserConstants.ENHET_ID
 
 const val GEOGRAFISK_ENHET_NR = "0101"
 const val GEOGRAFISK_ENHET_NR_2 = "0102"
-const val OVERORDNET_NR = "0200"
+const val OVERORDNET_NR = "0600"
+const val ROE_NR = "0676"
 const val UNDERORDNET_NR = "0103"
 const val ENHET_NAVN = "Enhet"
 const val ENHET_NAVN_2 = "Enhet2"

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/Norg2Mock.kt
@@ -67,13 +67,6 @@ suspend fun MockRequestHandleScope.getNorg2Response(request: HttpRequestData): H
                 RsOrganisering(
                     orgType = "ENHET",
                     organiserer = RsSimpleEnhet(VEST_VIKEN_ENHET_ID, "Overordnet"),
-                    organisertUnder = RsSimpleEnhet(UNDERORDNET_NR, "Underordnet"),
-                    gyldigFra = null,
-                    gyldigTil = null,
-                ),
-                RsOrganisering(
-                    orgType = "ENHET",
-                    organiserer = RsSimpleEnhet(VEST_VIKEN_ENHET_ID, "Overordnet"),
                     organisertUnder = RsSimpleEnhet(GEOGRAFISK_ENHET_NR, ENHET_NAVN),
                     gyldigFra = null,
                     gyldigTil = null,


### PR DESCRIPTION
Tilpasser lista med enheter man kan velge fra. Det viktigste er at det er mulig å velge Nav utland og ROE når i utgangspunktet er en arbeidstaker som er tildelt sin geografiske enhet. 

Omvendt: Hvis en arbeidstaker er tildelt Nav utland eller ROE må det være mulig å sende ham/hun tilbake til geografisk enhet. Det siste vil bare være mulig inne på enkeltperson (fra enhetens oversikt kan man velge flere og da er det ingen unik geografisk enhet man kan sende tilbake til).

<img width="875" height="395" alt="enhet" src="https://github.com/user-attachments/assets/f9984152-3fe9-40d2-8194-5d095a11f6fa" />
