### PR TITLE
IS-3642: Fjerne System-api for isaktivitetskrav og isdialogmotekandidat

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -43,8 +43,6 @@ spec:
         - application: syfooversiktsrv
         - application: istilgangskontroll
         - application: ismeroppfolging
-        - application: isaktivitetskrav
-        - application: isdialogmotekandidat
         - application: syfomotebehov
           namespace: team-esyfo
     outbound:

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -43,8 +43,6 @@ spec:
         - application: syfooversiktsrv
         - application: istilgangskontroll
         - application: ismeroppfolging
-        - application: isaktivitetskrav
-        - application: isdialogmotekandidat
         - application: syfomotebehov
           namespace: team-esyfo
     outbound:

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -53,15 +53,11 @@ data class Environment(
     val syfooversiktsrvApplicationName: String = "syfooversiktsrv",
     val istilgangskontrollApplicationName: String = "istilgangskontroll",
     val ismeroppfolgingApplicationName: String = "ismeroppfolging",
-    val isaktivitetskravApplicationName: String = "isaktivitetskrav",
-    val isdialogmotekandidatApplicationName: String = "isdialogmotekandidat",
     val systemAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
         syfomotebehovApplicationName,
         syfooversiktsrvApplicationName,
         istilgangskontrollApplicationName,
         ismeroppfolgingApplicationName,
-        isaktivitetskravApplicationName,
-        isdialogmotekandidatApplicationName,
     ),
 ) {
     fun jdbcUrl(): String {

--- a/src/main/kotlin/no/nav/syfo/api/internad/BehandlendeEnhetAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/api/internad/BehandlendeEnhetAPI.kt
@@ -48,14 +48,12 @@ fun Route.registrerPersonApi(
                 callId = callId,
                 token = token,
             )
-
-            enhetService.arbeidstakersBehandlendeEnhet(
+            val behandlendeEnhet = enhetService.arbeidstakersBehandlendeEnhet(
                 callId = callId,
                 personIdentNumber = personIdentNumber,
                 veilederToken = token,
             )
-                .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) }
-                .run { call.respond(this) }
+            call.respond(BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(behandlendeEnhet) )
         }
 
         get("/historikk") {

--- a/src/main/kotlin/no/nav/syfo/api/internad/BehandlendeEnhetAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/api/internad/BehandlendeEnhetAPI.kt
@@ -53,7 +53,7 @@ fun Route.registrerPersonApi(
                 personIdentNumber = personIdentNumber,
                 veilederToken = token,
             )
-            call.respond(BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(behandlendeEnhet) )
+            call.respond(BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(behandlendeEnhet))
         }
 
         get("/historikk") {

--- a/src/main/kotlin/no/nav/syfo/api/system/BehandlendeEnhetSystemAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/api/system/BehandlendeEnhetSystemAPI.kt
@@ -33,13 +33,12 @@ fun Route.registrerSystemApi(
             }
                 ?: throw IllegalArgumentException("Could not retrieve BehandlendeEnhet: No $NAV_PERSONIDENT_HEADER supplied in request header")
 
-            enhetService.arbeidstakersBehandlendeEnhet(
+            val behandlendeEnhet = enhetService.arbeidstakersBehandlendeEnhet(
                 callId = callId,
                 personIdentNumber = personIdentNumber,
                 veilederToken = null,
             )
-                .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) }
-                .run { call.respond(this) }
+            call.respond(BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(behandlendeEnhet))
         }
         post(systemdBehandlendeEnhetApiV2PersonIdentPath) {
             val callId = getCallId()

--- a/src/main/kotlin/no/nav/syfo/api/system/BehandlendeEnhetSystemAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/api/system/BehandlendeEnhetSystemAPI.kt
@@ -33,12 +33,13 @@ fun Route.registrerSystemApi(
             }
                 ?: throw IllegalArgumentException("Could not retrieve BehandlendeEnhet: No $NAV_PERSONIDENT_HEADER supplied in request header")
 
-            val behandlendeEnhet = enhetService.arbeidstakersBehandlendeEnhet(
+            enhetService.arbeidstakersBehandlendeEnhet(
                 callId = callId,
                 personIdentNumber = personIdentNumber,
                 veilederToken = null,
             )
-            call.respond(BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(behandlendeEnhet))
+                .let { BehandlendeEnhetResponseDTO.fromBehandlendeEnhet(it) }
+                .run { call.respond(this) }
         }
         post(systemdBehandlendeEnhetApiV2PersonIdentPath) {
             val callId = getCallId()

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -67,8 +67,6 @@ const val testSyfomotebehovClientId = "syfomotebehov-client-id"
 const val testSyfooversiktsrvClientId = "syfooversiktsrv-client-id"
 const val testIstilgangskontrollClientId = "istilgangskontroll-client-id"
 const val testIsMeroppfolgingClientId = "ismeroppfolging-client-id"
-const val testIsAktivitetskravClientId = "isaktivitetskrav-client-id"
-const val testIsDialogmotekandidatClientId = "isdialogmotekandidata-client-id"
 
 val testAzureAppPreAuthorizedApps = listOf(
     PreAuthorizedClient(
@@ -95,12 +93,4 @@ val testAzureAppPreAuthorizedApps = listOf(
         name = "dev-gcp:teamsykefravr:ismeroppfolging",
         clientId = testIsMeroppfolgingClientId,
     ),
-    PreAuthorizedClient(
-        name = "dev-gcp:teamsykefravr:isaktivitetskrav",
-        clientId = testIsAktivitetskravClientId,
-    ),
-    PreAuthorizedClient(
-        name = "dev-gcp:teamsykefravr:isdialogmotekandidat",
-        clientId = testIsDialogmotekandidatClientId,
-    )
 )


### PR DESCRIPTION
Fjerner disse system-tilgangene siden de aktuelle app'ene ikke bruker syfobehandlendeenhet lengre.