### PR TITLE
IS: Change log-level for identhendelse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/pdl/PdlClient.kt
@@ -55,7 +55,7 @@ class PdlClient(
                 val errorMessage =
                     "No Geografisk Tilknytning was found in response from PDL: No data was found in response"
                 log.error("Error while requesting person from PersonDataLosningen: $errorMessage")
-                throw throw RuntimeException(errorMessage)
+                throw RuntimeException(errorMessage)
             } else {
                 COUNT_CALL_PDL_GT_SUCCESS.increment()
                 return pdlPersonResponse.data.hentGeografiskTilknytning?.geografiskTilknytning()
@@ -153,8 +153,12 @@ class PdlClient(
                 val pdlIdenterResponse = response.body<PdlIdenterResponse>()
                 return if (!pdlIdenterResponse.errors.isNullOrEmpty()) {
                     COUNT_CALL_PDL_IDENTER_FAIL.increment()
-                    pdlIdenterResponse.errors.forEach {
-                        log.error("Error while requesting IdentList from PersonDataLosningen: ${it.errorMessage()}")
+                    pdlIdenterResponse.errors.forEach { error ->
+                        if (error.isOfTypeNotFound()) {
+                            log.warn("Error while requesting ident from PersonDataLosningen: ${error.errorMessage()}")
+                        } else {
+                            log.error("Error while requesting ident from PersonDataLosningen: ${error.errorMessage()}")
+                        }
                     }
                     null
                 } else {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/pdl/domain/PdlError.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/pdl/domain/PdlError.kt
@@ -7,7 +7,9 @@ data class PdlError(
     val locations: List<PdlErrorLocation>,
     val path: List<String>?,
     val extensions: PdlErrorExtension,
-) : Serializable
+) : Serializable {
+    fun isOfTypeNotFound() = this.extensions.code == "not_found"
+}
 
 data class PdlErrorLocation(
     val line: Int?,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumerService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumerService.kt
@@ -28,7 +28,7 @@ class IdenthendelseConsumerService(
                 kafkaConsumer.commitSync()
             }
         } catch (ex: Exception) {
-            log.error("Error running kafka consumer for pdl-aktor, unsubscribing and waiting $DELAY_ON_ERROR_SECONDS seconds for retry", ex)
+            log.warn("Error running kafka consumer for pdl-aktor, unsubscribing and waiting $DELAY_ON_ERROR_SECONDS seconds for retry", ex)
             kafkaConsumer.unsubscribe()
             delay(DELAY_ON_ERROR_SECONDS.seconds)
         }
@@ -36,7 +36,7 @@ class IdenthendelseConsumerService(
 
     companion object {
         private const val POLL_DURATION_SECONDS = 10L
-        private const val DELAY_ON_ERROR_SECONDS = 60L
+        private const val DELAY_ON_ERROR_SECONDS = 10L
         private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.identhendelse")
     }
 }


### PR DESCRIPTION
Disse feilene er ganske vanlige, og for å ikke støye loggene kan vi endre til warning-nivå. I tillegg trenger man ikke å vente i 60 sekunder, 10 holder nok.